### PR TITLE
Add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "alien-signals",
 	"version": "0.4.3",
 	"license": "MIT",
+	"description": "The fastest and lightest signal library.",
 	"packageManager": "pnpm@9.12.0",
 	"types": "./types/index.d.ts",
 	"exports": {


### PR DESCRIPTION
Always a good practice to have a package description.

Additionally, without a package.json `description`, some tools and sites default to the first few lines of the readme.

![CleanShot 2024-11-27 at 01 03 56@2x](https://github.com/user-attachments/assets/368e7d25-b0eb-4f53-a18c-b62236ad251c)
