### PR TITLE
pref(system): Clean up overdesign and reduce size

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -1,367 +1,353 @@
 export interface IEffect extends Subscriber {
-	nextNotify: IEffect | undefined;
-	notify(): void;
+  nextNotify: IEffect | undefined;
+  notify(): void;
 }
 
 export interface IComputed extends Dependency, Subscriber {
-	version: number;
-	update(): boolean;
+  version: number;
+  update(): boolean;
 }
 
 export interface Dependency {
-	subs: Link | undefined;
-	subsTail: Link | undefined;
-	lastTrackedId?: number;
+  subs: Link | undefined;
+  subsTail: Link | undefined;
+  lastTrackedId?: number;
 }
 
 export interface Subscriber {
-	flags: SubscriberFlags;
-	deps: Link | undefined;
-	depsTail: Link | undefined;
+  flags: SubscriberFlags;
+  deps: Link | undefined;
+  depsTail: Link | undefined;
 }
 
 export interface Link {
-	dep: Dependency | IComputed | (Dependency & IEffect);
-	sub: Subscriber | IComputed | (Dependency & IEffect) | IEffect;
-	version: number;
-	// Reuse to link prev stack in checkDirty
-	// Reuse to link prev stack in propagate
-	prevSub: Link | undefined;
-	nextSub: Link | undefined;
-	// Reuse to link next released link in linkPool
-	nextDep: Link | undefined;
+  dep: Dependency | IComputed | (Dependency & IEffect);
+  sub: Subscriber | IComputed | (Dependency & IEffect) | IEffect;
+  version: number;
+  // Reuse to link prev stack in checkDirty
+  // Reuse to link prev stack in propagate
+  prevSub: Link | undefined;
+  nextSub: Link | undefined;
+  // Reuse to link next released link in linkPool
+  nextDep: Link | undefined;
 }
 
 export const enum SubscriberFlags {
-	None = 0,
-	Tracking = 1 << 0,
-	CanPropagate = 1 << 1,
-	RunInnerEffects = 1 << 2,
-	ToCheckDirty = 1 << 3,
-	Dirty = 1 << 4,
+  None = 0,
+  Tracking = 1 << 0,
+  CanPropagate = 1 << 1,
+  RunInnerEffects = 1 << 2,
+  ToCheckDirty = 1 << 3,
+  Dirty = 1 << 4,
 }
 
 let batchDepth = 0;
 let queuedEffects: IEffect | undefined;
 let queuedEffectsTail: IEffect | undefined;
-let linkPool: Link | undefined;
 
 export function startBatch(): void {
-	++batchDepth;
+  ++batchDepth;
 }
 
 export function endBatch(): void {
-	if (!--batchDepth) {
-		drainQueuedEffects();
-	}
+  if (!--batchDepth) {
+    drainQueuedEffects();
+  }
 }
 
 function drainQueuedEffects(): void {
-	while (queuedEffects !== undefined) {
-		const effect = queuedEffects;
-		const queuedNext = effect.nextNotify;
-		if (queuedNext !== undefined) {
-			effect.nextNotify = undefined;
-			queuedEffects = queuedNext;
-		} else {
-			queuedEffects = undefined;
-			queuedEffectsTail = undefined;
-		}
-		effect.notify();
-	}
+  while (queuedEffects !== undefined) {
+    const effect = queuedEffects;
+    const queuedNext = effect.nextNotify;
+    if (queuedNext !== undefined) {
+      effect.nextNotify = undefined;
+      queuedEffects = queuedNext;
+    } else {
+      queuedEffects = undefined;
+      queuedEffectsTail = undefined;
+    }
+    effect.notify();
+  }
 }
 
 export function link(dep: Dependency, sub: Subscriber): Link {
-	const currentDep = sub.depsTail;
-	const nextDep = currentDep !== undefined
-		? currentDep.nextDep
-		: sub.deps;
-	if (nextDep !== undefined && nextDep.dep === dep) {
-		sub.depsTail = nextDep;
-		return nextDep;
-	} else {
-		return linkNewDep(dep, sub, nextDep, currentDep);
-	}
+  const currentDep = sub.depsTail;
+  const nextDep = currentDep !== undefined ? currentDep.nextDep : sub.deps;
+  if (nextDep !== undefined && nextDep.dep === dep) {
+    sub.depsTail = nextDep;
+    return nextDep;
+  } else {
+    return linkNewDep(dep, sub, nextDep, currentDep);
+  }
 }
 
-function linkNewDep(dep: Dependency, sub: Subscriber, nextDep: Link | undefined, depsTail: Link | undefined): Link {
-	let newLink: Link;
+function linkNewDep(
+  dep: Dependency,
+  sub: Subscriber,
+  nextDep: Link | undefined,
+  depsTail: Link | undefined,
+): Link {
+  const newLink: Link = {
+    dep,
+    sub,
+    version: 0,
+    nextDep,
+    prevSub: undefined,
+    nextSub: undefined,
+  };
 
-	if (linkPool !== undefined) {
-		newLink = linkPool;
-		linkPool = newLink.nextDep;
-		newLink.nextDep = nextDep;
-		newLink.dep = dep;
-		newLink.sub = sub;
-	} else {
-		newLink = {
-			dep,
-			sub,
-			version: 0,
-			nextDep,
-			prevSub: undefined,
-			nextSub: undefined,
-		};
-	}
+  if (depsTail === undefined) {
+    sub.deps = newLink;
+  } else {
+    depsTail.nextDep = newLink;
+  }
 
-	if (depsTail === undefined) {
-		sub.deps = newLink;
-	} else {
-		depsTail.nextDep = newLink;
-	}
+  if (dep.subs === undefined) {
+    dep.subs = newLink;
+  } else {
+    const oldTail = dep.subsTail!;
+    newLink.prevSub = oldTail;
+    oldTail.nextSub = newLink;
+  }
 
-	if (dep.subs === undefined) {
-		dep.subs = newLink;
-	} else {
-		const oldTail = dep.subsTail!;
-		newLink.prevSub = oldTail;
-		oldTail.nextSub = newLink;
-	}
+  sub.depsTail = newLink;
+  dep.subsTail = newLink;
 
-	sub.depsTail = newLink;
-	dep.subsTail = newLink;
-
-	return newLink;
+  return newLink;
 }
 
 // See https://github.com/stackblitz/alien-signals#about-propagate-and-checkdirty-functions
 export function propagate(subs: Link): void {
-	let targetFlag = SubscriberFlags.Dirty;
-	let link = subs;
-	let stack = 0;
-	let nextSub: Link | undefined;
+  let targetFlag = SubscriberFlags.Dirty;
+  let link = subs;
+  let stack = 0;
+  let nextSub: Link | undefined;
 
-	top: do {
-		const sub = link.sub;
-		const subFlags = sub.flags;
+  top: do {
+    const sub = link.sub;
+    const subFlags = sub.flags;
 
-		if (!(subFlags & SubscriberFlags.Tracking)) {
-			let canPropagate = !(subFlags >> 2);
-			if (!canPropagate && subFlags & SubscriberFlags.CanPropagate) {
-				sub.flags &= ~SubscriberFlags.CanPropagate;
-				canPropagate = true;
-			}
-			if (canPropagate) {
-				sub.flags |= targetFlag;
-				const subSubs = (sub as Dependency).subs;
-				if (subSubs !== undefined) {
-					if (subSubs.nextSub !== undefined) {
-						subSubs.prevSub = subs;
-						link = subs = subSubs;
-						targetFlag = SubscriberFlags.ToCheckDirty;
-						++stack;
-					} else {
-						link = subSubs;
-						targetFlag = 'notify' in sub
-							? SubscriberFlags.RunInnerEffects
-							: SubscriberFlags.ToCheckDirty;
-					}
-					continue;
-				}
-				if ('notify' in sub) {
-					if (queuedEffectsTail !== undefined) {
-						queuedEffectsTail.nextNotify = sub;
-					} else {
-						queuedEffects = sub;
-					}
-					queuedEffectsTail = sub;
-				}
-			} else if (!(sub.flags & targetFlag)) {
-				sub.flags |= targetFlag;
-			}
-		} else if (isValidLink(link, sub)) {
-			if (!(subFlags >> 2)) {
-				sub.flags |= targetFlag | SubscriberFlags.CanPropagate;
-				const subSubs = (sub as Dependency).subs;
-				if (subSubs !== undefined) {
-					if (subSubs.nextSub !== undefined) {
-						subSubs.prevSub = subs;
-						link = subs = subSubs;
-						targetFlag = SubscriberFlags.ToCheckDirty;
-						++stack;
-					} else {
-						link = subSubs;
-						targetFlag = 'notify' in sub
-							? SubscriberFlags.RunInnerEffects
-							: SubscriberFlags.ToCheckDirty;
-					}
-					continue;
-				}
-			} else if (!(sub.flags & targetFlag)) {
-				sub.flags |= targetFlag;
-			}
-		}
+    if (!(subFlags & SubscriberFlags.Tracking)) {
+      let canPropagate = !(subFlags >> 2);
+      if (!canPropagate && subFlags & SubscriberFlags.CanPropagate) {
+        sub.flags &= ~SubscriberFlags.CanPropagate;
+        canPropagate = true;
+      }
+      if (canPropagate) {
+        sub.flags |= targetFlag;
+        const subSubs = (sub as Dependency).subs;
+        if (subSubs !== undefined) {
+          if (subSubs.nextSub !== undefined) {
+            subSubs.prevSub = subs;
+            link = subs = subSubs;
+            targetFlag = SubscriberFlags.ToCheckDirty;
+            ++stack;
+          } else {
+            link = subSubs;
+            targetFlag =
+              "notify" in sub
+                ? SubscriberFlags.RunInnerEffects
+                : SubscriberFlags.ToCheckDirty;
+          }
+          continue;
+        }
+        if ("notify" in sub) {
+          if (queuedEffectsTail !== undefined) {
+            queuedEffectsTail.nextNotify = sub;
+          } else {
+            queuedEffects = sub;
+          }
+          queuedEffectsTail = sub;
+        }
+      } else if (!(sub.flags & targetFlag)) {
+        sub.flags |= targetFlag;
+      }
+    } else if (isValidLink(link, sub)) {
+      if (!(subFlags >> 2)) {
+        sub.flags |= targetFlag | SubscriberFlags.CanPropagate;
+        const subSubs = (sub as Dependency).subs;
+        if (subSubs !== undefined) {
+          if (subSubs.nextSub !== undefined) {
+            subSubs.prevSub = subs;
+            link = subs = subSubs;
+            targetFlag = SubscriberFlags.ToCheckDirty;
+            ++stack;
+          } else {
+            link = subSubs;
+            targetFlag =
+              "notify" in sub
+                ? SubscriberFlags.RunInnerEffects
+                : SubscriberFlags.ToCheckDirty;
+          }
+          continue;
+        }
+      } else if (!(sub.flags & targetFlag)) {
+        sub.flags |= targetFlag;
+      }
+    }
 
-		if ((nextSub = subs.nextSub) === undefined) {
-			if (stack) {
-				let dep = subs.dep;
-				do {
-					--stack;
-					const depSubs = dep.subs!;
-					const prevLink = depSubs.prevSub!;
-					depSubs.prevSub = undefined;
-					link = subs = prevLink.nextSub!;
-					if (subs !== undefined) {
-						targetFlag = stack
-							? SubscriberFlags.ToCheckDirty
-							: SubscriberFlags.Dirty;
-						continue top;
-					}
-					dep = prevLink.dep;
-				} while (stack);
-			}
-			break;
-		}
-		if (link !== subs) {
-			targetFlag = stack
-				? SubscriberFlags.ToCheckDirty
-				: SubscriberFlags.Dirty;
-		}
-		link = subs = nextSub;
-	} while (true);
+    if ((nextSub = subs.nextSub) === undefined) {
+      if (stack) {
+        let dep = subs.dep;
+        do {
+          --stack;
+          const depSubs = dep.subs!;
+          const prevLink = depSubs.prevSub!;
+          depSubs.prevSub = undefined;
+          link = subs = prevLink.nextSub!;
+          if (subs !== undefined) {
+            targetFlag = stack
+              ? SubscriberFlags.ToCheckDirty
+              : SubscriberFlags.Dirty;
+            continue top;
+          }
+          dep = prevLink.dep;
+        } while (stack);
+      }
+      break;
+    }
+    if (link !== subs) {
+      targetFlag = stack ? SubscriberFlags.ToCheckDirty : SubscriberFlags.Dirty;
+    }
+    link = subs = nextSub;
+  } while (true);
 
-	if (!batchDepth) {
-		drainQueuedEffects();
-	}
+  if (!batchDepth) {
+    drainQueuedEffects();
+  }
 }
 
 function isValidLink(subLink: Link, sub: Subscriber) {
-	const depsTail = sub.depsTail;
-	if (depsTail !== undefined) {
-		let link = sub.deps!;
-		do {
-			if (link === subLink) {
-				return true;
-			}
-			if (link === depsTail) {
-				break;
-			}
-			link = link.nextDep!;
-		} while (link !== undefined);
-	}
-	return false;
+  const depsTail = sub.depsTail;
+  if (depsTail !== undefined) {
+    let link = sub.deps!;
+    do {
+      if (link === subLink) {
+        return true;
+      }
+      if (link === depsTail) {
+        break;
+      }
+      link = link.nextDep!;
+    } while (link !== undefined);
+  }
+  return false;
 }
 
 // See https://github.com/stackblitz/alien-signals#about-propagate-and-checkdirty-functions
 export function checkDirty(deps: Link): boolean {
-	let stack = 0;
-	let dirty: boolean;
-	let nextDep: Link | undefined;
+  let stack = 0;
+  let dirty: boolean;
+  let nextDep: Link | undefined;
 
-	top: do {
-		dirty = false;
-		const dep = deps.dep;
-		if ('update' in dep) {
-			if (dep.version !== deps.version) {
-				dirty = true;
-			} else {
-				const depFlags = dep.flags;
-				if (depFlags & SubscriberFlags.Dirty) {
-					dirty = dep.update();
-				} else if (depFlags & SubscriberFlags.ToCheckDirty) {
-					dep.subs!.prevSub = deps;
-					deps = dep.deps!;
-					++stack;
-					continue;
-				}
-			}
-		}
-		if (dirty || (nextDep = deps.nextDep) === undefined) {
-			if (stack) {
-				let sub = deps.sub as IComputed;
-				do {
-					--stack;
-					const subSubs = sub.subs!;
-					const prevLink = subSubs.prevSub!;
-					subSubs.prevSub = undefined;
-					if (dirty) {
-						if (sub.update()) {
-							sub = prevLink.sub as IComputed;
-							dirty = true;
-							continue;
-						}
-					} else {
-						sub.flags &= ~SubscriberFlags.ToCheckDirty;
-					}
-					deps = prevLink.nextDep!;
-					if (deps !== undefined) {
-						continue top;
-					}
-					sub = prevLink.sub as IComputed;
-					dirty = false;
-				} while (stack);
-			}
-			return dirty;
-		}
-		deps = nextDep;
-	} while (true);
+  top: do {
+    dirty = false;
+    const dep = deps.dep;
+    if ("update" in dep) {
+      if (dep.version !== deps.version) {
+        dirty = true;
+      } else {
+        const depFlags = dep.flags;
+        if (depFlags & SubscriberFlags.Dirty) {
+          dirty = dep.update();
+        } else if (depFlags & SubscriberFlags.ToCheckDirty) {
+          dep.subs!.prevSub = deps;
+          deps = dep.deps!;
+          ++stack;
+          continue;
+        }
+      }
+    }
+    if (dirty || (nextDep = deps.nextDep) === undefined) {
+      if (stack) {
+        let sub = deps.sub as IComputed;
+        do {
+          --stack;
+          const subSubs = sub.subs!;
+          const prevLink = subSubs.prevSub!;
+          subSubs.prevSub = undefined;
+          if (dirty) {
+            if (sub.update()) {
+              sub = prevLink.sub as IComputed;
+              dirty = true;
+              continue;
+            }
+          } else {
+            sub.flags &= ~SubscriberFlags.ToCheckDirty;
+          }
+          deps = prevLink.nextDep!;
+          if (deps !== undefined) {
+            continue top;
+          }
+          sub = prevLink.sub as IComputed;
+          dirty = false;
+        } while (stack);
+      }
+      return dirty;
+    }
+    deps = nextDep;
+  } while (true);
 }
 
 export function startTrack(sub: Subscriber): void {
-	sub.depsTail = undefined;
-	sub.flags = SubscriberFlags.Tracking;
+  sub.depsTail = undefined;
+  sub.flags = SubscriberFlags.Tracking;
 }
 
 export function endTrack(sub: Subscriber): void {
-	const depsTail = sub.depsTail;
-	if (depsTail !== undefined) {
-		if (depsTail.nextDep !== undefined) {
-			clearTrack(depsTail.nextDep);
-			depsTail.nextDep = undefined;
-		}
-	} else if (sub.deps !== undefined) {
-		clearTrack(sub.deps);
-		sub.deps = undefined;
-	}
-	sub.flags &= ~SubscriberFlags.Tracking;
+  const depsTail = sub.depsTail;
+  if (depsTail !== undefined) {
+    if (depsTail.nextDep !== undefined) {
+      clearTrack(depsTail.nextDep);
+      depsTail.nextDep = undefined;
+    }
+  } else if (sub.deps !== undefined) {
+    clearTrack(sub.deps);
+    sub.deps = undefined;
+  }
+  sub.flags &= ~SubscriberFlags.Tracking;
 }
 
 function clearTrack(link: Link): void {
-	do {
-		const dep = link.dep;
-		const nextDep = link.nextDep;
-		const nextSub = link.nextSub;
-		const prevSub = link.prevSub;
+  do {
+    const dep = link.dep,
+      nextDep = link.nextDep,
+      nextSub = link.nextSub,
+      prevSub = link.prevSub;
+    link.nextDep = undefined;
 
-		if (nextSub !== undefined) {
-			nextSub.prevSub = prevSub;
-			link.nextSub = undefined;
-		} else {
-			dep.subsTail = prevSub;
-			if ('lastTrackedId' in dep) {
-				dep.lastTrackedId = 0;
-			}
-		}
+    if (nextSub !== undefined) {
+      nextSub.prevSub = prevSub;
+      link.nextSub = undefined;
+    } else {
+      dep.subsTail = prevSub;
+      if ("lastTrackedId" in dep) {
+        dep.lastTrackedId = 0;
+      }
+    }
 
-		if (prevSub !== undefined) {
-			prevSub.nextSub = nextSub;
-			link.prevSub = undefined;
-		} else {
-			dep.subs = nextSub;
-		}
+    if (prevSub !== undefined) {
+      prevSub.nextSub = nextSub;
+      link.prevSub = undefined;
+    } else {
+      dep.subs = nextSub;
+    }
 
-		// @ts-expect-error
-		link.dep = undefined;
-		// @ts-expect-error
-		link.sub = undefined;
-		link.nextDep = linkPool;
-		linkPool = link;
-
-		if (dep.subs === undefined && 'deps' in dep) {
-			if ('notify' in dep) {
-				dep.flags = SubscriberFlags.None;
-			} else {
-				dep.flags |= SubscriberFlags.Dirty;
-			}
-			const depDeps = dep.deps;
-			if (depDeps !== undefined) {
-				link = depDeps;
-				dep.depsTail!.nextDep = nextDep;
-				dep.deps = undefined;
-				dep.depsTail = undefined;
-				continue;
-			}
-		}
-		link = nextDep!;
-	} while (link !== undefined);
+    if (dep.subs === undefined && "deps" in dep) {
+      if ("notify" in dep) {
+        dep.flags = SubscriberFlags.None;
+      } else {
+        dep.flags |= SubscriberFlags.Dirty;
+      }
+      const depDeps = dep.deps;
+      if (depDeps !== undefined) {
+        link = depDeps;
+        dep.depsTail!.nextDep = nextDep;
+        dep.deps = undefined;
+        dep.depsTail = undefined;
+        continue;
+      }
+    }
+    link = nextDep!;
+  } while (link !== undefined);
 }


### PR DESCRIPTION
## Before

esm/index.mjs  15.3kb

clk: ~0.05 GHz
cpu: Apple M3 Max
runtime: node 22.9.0 (arm64-darwin)

| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `790.38 ns/iter` | `773.45 ns` | `800.21 ns` | `820.24 ns` | `825.65 ns` |
| propagate: 10 * 1    | `  7.03 µs/iter` | `  6.92 µs` | `  7.09 µs` | `  7.14 µs` | `  7.14 µs` |
| propagate: 100 * 1   | ` 68.82 µs/iter` | ` 66.13 µs` | ` 67.50 µs` | ` 90.67 µs` | ` 94.79 µs` |
| propagate: 1 * 10    | `  4.02 µs/iter` | `  4.00 µs` | `  4.02 µs` | `  4.06 µs` | `  4.13 µs` |
| propagate: 10 * 10   | ` 39.42 µs/iter` | ` 38.80 µs` | ` 39.67 µs` | ` 39.91 µs` | ` 40.14 µs` |
| propagate: 100 * 10  | `399.07 µs/iter` | `381.33 µs` | `408.83 µs` | `449.50 µs` | `468.04 µs` |
| propagate: 1 * 100   | ` 35.48 µs/iter` | ` 35.00 µs` | ` 35.60 µs` | ` 35.72 µs` | ` 35.84 µs` |
| propagate: 10 * 100  | `355.62 µs/iter` | `347.46 µs` | `355.63 µs` | `386.71 µs` | `404.17 µs` |
| propagate: 100 * 100 | `  3.55 ms/iter` | `  3.50 ms` | `  3.56 ms` | `  3.64 ms` | `  3.66 ms` |

## After

esm/index.mjs  15.0kb

clk: ~0.05 GHz
cpu: Apple M3 Max
runtime: node 22.9.0 (arm64-darwin)

| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `786.68 ns/iter` | `770.51 ns` | `792.65 ns` | `807.85 ns` | `814.28 ns` |
| propagate: 10 * 1    | `  6.87 µs/iter` | `  6.79 µs` | `  6.90 µs` | `  6.94 µs` | `  6.95 µs` |
| propagate: 100 * 1   | ` 67.66 µs/iter` | ` 65.00 µs` | ` 66.25 µs` | ` 89.46 µs` | `100.38 µs` |
| propagate: 1 * 10    | `  3.99 µs/iter` | `  3.96 µs` | `  3.99 µs` | `  4.05 µs` | `  4.05 µs` |
| propagate: 10 * 10   | ` 39.59 µs/iter` | ` 38.96 µs` | ` 39.91 µs` | ` 39.98 µs` | ` 40.06 µs` |
| propagate: 100 * 10  | `394.43 µs/iter` | `380.50 µs` | `400.00 µs` | `439.25 µs` | `451.88 µs` |
| propagate: 1 * 100   | ` 35.38 µs/iter` | ` 35.01 µs` | ` 35.63 µs` | ` 35.72 µs` | ` 35.85 µs` |
| propagate: 10 * 100  | `356.91 µs/iter` | `349.58 µs` | `357.29 µs` | `391.96 µs` | `408.08 µs` |
| propagate: 100 * 100 | `  3.52 ms/iter` | `  3.47 ms` | `  3.54 ms` | `  3.63 ms` | `  3.63 ms` |

## Why?

Reusing Link objects does not save or speed up, but leaves many design traps. Linking empty objects all the time will result in garbage collection not being possible, and the next stage will reset the link before releasing it.

This PR removes this excessive design and directly discards the link when it is no longer needed to facilitate timely garbage collection.