### PR TITLE
perf(system): store value instead of version number in Link for dirty check

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -79,9 +79,8 @@ export function link(dep: Dependency, sub: Subscriber): Link {
 	if (nextDep !== undefined && nextDep.dep === dep) {
 		sub.depsTail = nextDep;
 		return nextDep;
-	} else {
-		return linkNewDep(dep, sub, nextDep, currentDep);
 	}
+	return linkNewDep(dep, sub, nextDep, currentDep);
 }
 
 function linkNewDep(dep: Dependency, sub: Subscriber, nextDep: Link | undefined, depsTail: Link | undefined): Link {

--- a/src/system.ts
+++ b/src/system.ts
@@ -4,11 +4,11 @@ export interface IEffect extends Subscriber {
 }
 
 export interface IComputed extends Dependency, Subscriber {
-	version: number;
-	update(): boolean;
+	update(): any;
 }
 
 export interface Dependency {
+	currentValue?: any;
 	subs: Link | undefined;
 	subsTail: Link | undefined;
 	lastTrackedId?: number;
@@ -23,7 +23,7 @@ export interface Subscriber {
 export interface Link {
 	dep: Dependency | IComputed | (Dependency & IEffect);
 	sub: Subscriber | IComputed | (Dependency & IEffect) | IEffect;
-	version: number;
+	value: any;
 	// Reuse to link prev stack in checkDirty
 	// Reuse to link prev stack in propagate
 	prevSub: Link | undefined;
@@ -97,7 +97,7 @@ function linkNewDep(dep: Dependency, sub: Subscriber, nextDep: Link | undefined,
 		newLink = {
 			dep,
 			sub,
-			version: 0,
+			value: undefined,
 			nextDep,
 			prevSub: undefined,
 			nextSub: undefined,
@@ -243,47 +243,51 @@ function isValidLink(subLink: Link, sub: Subscriber) {
 }
 
 // See https://github.com/stackblitz/alien-signals#about-propagate-and-checkdirty-functions
-export function checkDirty(deps: Link): boolean {
+export function checkDirty(link: Link): boolean {
 	let stack = 0;
 	let dirty: boolean;
 	let nextDep: Link | undefined;
 
 	top: do {
 		dirty = false;
-		const dep = deps.dep;
+		const dep = link.dep;
 		if ('update' in dep) {
-			if (dep.version !== deps.version) {
-				dirty = true;
-			} else {
-				const depFlags = dep.flags;
-				if (depFlags & SubscriberFlags.Dirty) {
-					dirty = dep.update();
-				} else if (depFlags & SubscriberFlags.ToCheckDirty) {
-					dep.subs!.prevSub = deps;
-					deps = dep.deps!;
-					++stack;
-					continue;
+			const depFlags = dep.flags;
+			if (depFlags & SubscriberFlags.Dirty) {
+				if (dep.update() !== link.value) {
+					dirty = true;
 				}
+			} else if (depFlags & SubscriberFlags.ToCheckDirty) {
+				dep.subs!.prevSub = link;
+				link = dep.deps!;
+				++stack;
+				continue;
+			} else if (dep.currentValue !== link.value) {
+				dirty = true;
+			}
+		} else if ('currentValue' in dep) {
+			if (dep.currentValue !== link.value) {
+				dirty = true;
 			}
 		}
-		if (dirty || (nextDep = deps.nextDep) === undefined) {
+		if (dirty || (nextDep = link.nextDep) === undefined) {
 			if (stack) {
-				let sub = deps.sub as IComputed;
+				let sub = link.sub as IComputed;
 				do {
 					--stack;
 					const subSubs = sub.subs!;
 					const prevLink = subSubs.prevSub!;
 					subSubs.prevSub = undefined;
 					if (dirty) {
-						if (sub.update()) {
+						if (sub.update() !== prevLink.value) {
 							sub = prevLink.sub as IComputed;
 							continue;
 						}
 					} else {
 						sub.flags &= ~SubscriberFlags.ToCheckDirty;
 					}
-					deps = prevLink.nextDep!;
-					if (deps !== undefined) {
+					link = prevLink.nextDep!;
+					if (link !== undefined) {
 						continue top;
 					}
 					sub = prevLink.sub as IComputed;
@@ -292,7 +296,7 @@ export function checkDirty(deps: Link): boolean {
 			}
 			return dirty;
 		}
-		deps = nextDep;
+		link = nextDep;
 	} while (true);
 }
 
@@ -343,6 +347,7 @@ function clearTrack(link: Link): void {
 		link.dep = undefined;
 		// @ts-expect-error
 		link.sub = undefined;
+		link.value = undefined;
 		link.nextDep = linkPool;
 		linkPool = link;
 


### PR DESCRIPTION
Use values ​​instead of version number in Link to simplify the algorithm.

Performance improvement is about 2~4.x%. Memory usage has been slightly improved.

#### master branch

| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `  1.48 µs/iter` | `  1.47 µs` | `  1.49 µs` | `  1.50 µs` | `  1.51 µs` |
| propagate: 1 * 10    | `  7.77 µs/iter` | `  7.76 µs` | `  7.78 µs` | `  7.79 µs` | `  7.79 µs` |
| propagate: 1 * 100   | ` 68.80 µs/iter` | ` 67.88 µs` | ` 68.75 µs` | ` 72.33 µs` | ` 96.71 µs` |
| propagate: 10 * 1    | ` 13.20 µs/iter` | ` 13.19 µs` | ` 13.20 µs` | ` 13.21 µs` | ` 13.21 µs` |
| propagate: 10 * 10   | ` 75.89 µs/iter` | ` 75.00 µs` | ` 75.71 µs` | ` 81.42 µs` | `104.33 µs` |
| propagate: 10 * 100  | `685.36 µs/iter` | `680.50 µs` | `686.17 µs` | `706.83 µs` | `726.17 µs` |
| propagate: 100 * 1   | `130.18 µs/iter` | `129.00 µs` | `130.00 µs` | `135.79 µs` | `163.08 µs` |
| propagate: 100 * 10  | `754.27 µs/iter` | `748.33 µs` | `754.04 µs` | `776.04 µs` | `785.08 µs` |
| propagate: 100 * 100 | `  6.86 ms/iter` | `  6.81 ms` | `  6.88 ms` | `  7.01 ms` | `  7.02 ms` |

#### This PR

| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `  1.45 µs/iter` | `  1.44 µs` | `  1.44 µs` | `  1.50 µs` | `  1.73 µs` |
| propagate: 1 * 10    | `  7.44 µs/iter` | `  7.42 µs` | `  7.44 µs` | `  7.45 µs` | `  7.45 µs` |
| propagate: 1 * 100   | ` 65.88 µs/iter` | ` 64.92 µs` | ` 65.79 µs` | ` 71.46 µs` | `144.25 µs` |
| propagate: 10 * 1    | ` 12.93 µs/iter` | ` 12.92 µs` | ` 12.94 µs` | ` 12.94 µs` | ` 12.94 µs` |
| propagate: 10 * 10   | ` 72.63 µs/iter` | ` 71.63 µs` | ` 72.29 µs` | ` 84.38 µs` | `255.42 µs` |
| propagate: 10 * 100  | `655.26 µs/iter` | `650.33 µs` | `655.29 µs` | `695.96 µs` | `720.38 µs` |
| propagate: 100 * 1   | `127.43 µs/iter` | `126.00 µs` | `126.88 µs` | `147.54 µs` | `246.33 µs` |
| propagate: 100 * 10  | `724.77 µs/iter` | `715.13 µs` | `720.13 µs` | `878.00 µs` | `  1.11 ms` |
| propagate: 100 * 100 | `  6.56 ms/iter` | `  6.51 ms` | `  6.59 ms` | `  6.77 ms` | `  6.83 ms` |