### PR TITLE
chore(bench): add complex object test

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"semi": true,
+	"singleQuote": true,
+	"arrowParens": "avoid",
+	"useTabs": true
+}

--- a/benchs/complex.mjs
+++ b/benchs/complex.mjs
@@ -1,0 +1,24 @@
+import { run, bench, boxplot } from 'mitata';
+import { computed, effect, signal } from '../esm/index.mjs';
+
+boxplot(() => {
+	bench('complex: $w * $h', function* (state) {
+		const w = state.get('w');
+		const h = state.get('h');
+		const src = signal({ w, h });
+		for (let i = 0; i < w; i++) {
+			let last = src;
+			for (let j = 0; j < h; j++) {
+				const prev = last;
+				last = computed(() => ({ [`${i}-${j}`]: prev.get() }));
+			}
+			effect(() => last.get());
+		}
+
+		yield () => src.set({ upstream: src.get() });
+	})
+		.args('h', [1, 10, 100])
+		.args('w', [1, 10, 100]);
+});
+
+run({ format: 'markdown' });


### PR DESCRIPTION
The original intention of adding it is because the comparison method of number and object in JS is inconsistent. This is to verify whether some modifications affect the performance because value is an object.