### PR TITLE
fix: should check currentValue when the intermediate computed checkDirty is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,22 +159,25 @@ export function checkDirty(link: Link): boolean {
 	do {
 		const dep = link.dep;
 		if ('update' in dep) {
-			if (dep.version !== link.version) {
-				return true;
-			}
 			const depFlags = dep.flags;
+			const linkValue = link.value;
 			if (depFlags & SubscriberFlags.Dirty) {
-				if (dep.update()) {
+				if (dep.update() !== linkValue) {
 					return true;
 				}
 			} else if (depFlags & SubscriberFlags.ToCheckDirty) {
 				if (checkDirty(dep.deps!)) {
-					if (dep.update()) {
+					if (dep.update() !== linkValue) {
 						return true;
 					}
 				} else {
-					dep.flags &= ~SubscriberFlags.ToCheckDirty;
+					dep.flags = depFlags & ~SubscriberFlags.ToCheckDirty;
+					if (dep.currentValue !== linkValue) {
+						return true;
+					}
 				}
+			} else if (dep.currentValue !== linkValue) {
+				return true;
 			}
 		}
 		link = link.nextDep!;

--- a/src/system.ts
+++ b/src/system.ts
@@ -283,6 +283,11 @@ export function checkDirty(link: Link): boolean {
 						}
 					} else {
 						sub.flags &= ~SubscriberFlags.ToCheckDirty;
+						if (sub.currentValue !== prevLink.value) {
+							dirty = true;
+							sub = prevLink.sub as IComputed;
+							continue;
+						}
 					}
 					link = prevLink.nextDep!;
 					if (link !== undefined) {

--- a/tests/computed.spec.ts
+++ b/tests/computed.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import { computed, signal } from '../src';
+
+test('should correctly propagate changes through computed signals', () => {
+	const src = signal(0);
+	const c1 = computed(() => src.get() % 2);
+	const c2 = computed(() => c1.get());
+	const c3 = computed(() => c2.get());
+
+	c3.get();
+	src.set(1); // c1 -> dirty, c2 -> toCheckDirty, c3 -> toCheckDirty
+	c2.get(); // c1 -> none, c2 -> none
+	src.set(3); // c1 -> dirty, c2 -> toCheckDirty
+
+	expect(c3.get()).toBe(1);
+});


### PR DESCRIPTION
Failed test:

```ts
const src = signal(0);
const c1 = computed(() => src.get() % 2);
const c2 = computed(() => c1.get());
const c3 = computed(() => c2.get());

c3.get();
src.set(1); // c1 -> dirty, c2 -> toCheckDirty, c3 -> toCheckDirty
c2.get(); // c1 -> none, c2 -> none
src.set(3); // c1 -> dirty, c2 -> toCheckDirty

expect(c3.get()).toBe(1); // got 0
```