### PR TITLE
perf: remove the extra else in propagate

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -71,9 +71,7 @@ function drainQueuedEffects(): void {
 
 export function link(dep: Dependency, sub: Subscriber): Link {
 	const currentDep = sub.depsTail;
-	const nextDep = currentDep !== undefined
-		? currentDep.nextDep
-		: sub.deps;
+	const nextDep = currentDep !== undefined ? currentDep.nextDep : sub.deps;
 	if (nextDep !== undefined && nextDep.dep === dep) {
 		sub.depsTail = nextDep;
 		return nextDep;
@@ -81,7 +79,12 @@ export function link(dep: Dependency, sub: Subscriber): Link {
 	return linkNewDep(dep, sub, nextDep, currentDep);
 }
 
-function linkNewDep(dep: Dependency, sub: Subscriber, nextDep: Link | undefined, depsTail: Link | undefined): Link {
+function linkNewDep(
+	dep: Dependency,
+	sub: Subscriber,
+	nextDep: Link | undefined,
+	depsTail: Link | undefined,
+): Link {
 	let newLink: Link;
 
 	if (linkPool !== undefined) {
@@ -133,14 +136,10 @@ export function propagate(subs: Link): void {
 
 		if (!(subFlags & SubscriberFlags.Tracking)) {
 			if (
-				(
-					!(subFlags >> 2)
-					&& (sub.flags = subFlags | targetFlag, true)
-				)
-				|| (
-					subFlags & SubscriberFlags.Recursed
-					&& (sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag, true)
-				)
+				(!(subFlags >> 2) && ((sub.flags = subFlags | targetFlag), true)) ||
+				(subFlags & SubscriberFlags.Recursed &&
+					((sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag),
+					true))
 			) {
 				const subSubs = (sub as Dependency).subs;
 				if (subSubs !== undefined) {
@@ -151,9 +150,10 @@ export function propagate(subs: Link): void {
 						++stack;
 					} else {
 						link = subSubs;
-						targetFlag = 'notify' in sub
-							? SubscriberFlags.InnerEffectsPending
-							: SubscriberFlags.ToCheckDirty;
+						targetFlag =
+							'notify' in sub
+								? SubscriberFlags.InnerEffectsPending
+								: SubscriberFlags.ToCheckDirty;
 					}
 					continue;
 				}
@@ -165,8 +165,6 @@ export function propagate(subs: Link): void {
 					}
 					queuedEffectsTail = sub;
 				}
-			} else {
-				sub.flags = subFlags | targetFlag;
 			}
 		} else if (isValidLink(link, sub)) {
 			if (!(subFlags >> 2)) {
@@ -180,9 +178,10 @@ export function propagate(subs: Link): void {
 						++stack;
 					} else {
 						link = subSubs;
-						targetFlag = 'notify' in sub
-							? SubscriberFlags.InnerEffectsPending
-							: SubscriberFlags.ToCheckDirty;
+						targetFlag =
+							'notify' in sub
+								? SubscriberFlags.InnerEffectsPending
+								: SubscriberFlags.ToCheckDirty;
 					}
 					continue;
 				}
@@ -212,9 +211,7 @@ export function propagate(subs: Link): void {
 			break;
 		}
 		if (link !== subs) {
-			targetFlag = stack
-				? SubscriberFlags.ToCheckDirty
-				: SubscriberFlags.Dirty;
+			targetFlag = stack ? SubscriberFlags.ToCheckDirty : SubscriberFlags.Dirty;
 		}
 		link = subs = nextSub;
 	} while (true);
@@ -228,7 +225,11 @@ export function shallowPropagate(link: Link): void {
 	do {
 		const updateSub = link.sub;
 		const updateSubFlags = updateSub.flags;
-		if ((updateSubFlags & (SubscriberFlags.ToCheckDirty | SubscriberFlags.Dirty)) === SubscriberFlags.ToCheckDirty) {
+		if (
+			(updateSubFlags &
+				(SubscriberFlags.ToCheckDirty | SubscriberFlags.Dirty)) ===
+			SubscriberFlags.ToCheckDirty
+		) {
 			updateSub.flags = updateSubFlags | SubscriberFlags.Dirty;
 		}
 		link = link.nextSub!;

--- a/src/system.ts
+++ b/src/system.ts
@@ -134,8 +134,8 @@ export function propagate(subs: Link): void {
 		if (!(subFlags & SubscriberFlags.Tracking)) {
 			sub.flags = subFlags | targetFlag;
 			if (
-				!(subFlags >> 2) ||
-				(
+				!(subFlags >> 2)
+				|| (
 					subFlags & SubscriberFlags.Recursed
 					&& (sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag, true)
 				)

--- a/src/system.ts
+++ b/src/system.ts
@@ -168,8 +168,9 @@ export function propagate(subs: Link): void {
 				}
 			}
 		} else if (isValidLink(link, sub)) {
+			sub.flags = targetFlag = subFlags | targetFlag;
 			if (!(subFlags >> 2)) {
-				sub.flags = subFlags | targetFlag | SubscriberFlags.Recursed;
+				sub.flags = targetFlag | SubscriberFlags.Recursed;
 				const subSubs = (sub as Dependency).subs;
 				if (subSubs !== undefined) {
 					if (subSubs.nextSub !== undefined) {
@@ -186,8 +187,6 @@ export function propagate(subs: Link): void {
 					}
 					continue;
 				}
-			} else if (!(subFlags & targetFlag)) {
-				sub.flags = subFlags | targetFlag;
 			}
 		}
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -81,12 +81,7 @@ export function link(dep: Dependency, sub: Subscriber): Link {
 	return linkNewDep(dep, sub, nextDep, currentDep);
 }
 
-function linkNewDep(
-	dep: Dependency,
-	sub: Subscriber,
-	nextDep: Link | undefined,
-	depsTail: Link | undefined
-): Link {
+function linkNewDep(dep: Dependency, sub: Subscriber, nextDep: Link | undefined, depsTail: Link | undefined): Link {
 	let newLink: Link;
 
 	if (linkPool !== undefined) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -135,8 +135,9 @@ export function propagate(subs: Link): void {
 		const subFlags = sub.flags;
 
 		if (!(subFlags & SubscriberFlags.Tracking)) {
+			sub.flags = subFlags | targetFlag;
 			if (
-				(!(subFlags >> 2) && ((sub.flags = subFlags | targetFlag), true)) ||
+				!(subFlags >> 2) ||
 				(subFlags & SubscriberFlags.Recursed &&
 					((sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag),
 					true))

--- a/src/system.ts
+++ b/src/system.ts
@@ -71,7 +71,9 @@ function drainQueuedEffects(): void {
 
 export function link(dep: Dependency, sub: Subscriber): Link {
 	const currentDep = sub.depsTail;
-	const nextDep = currentDep !== undefined ? currentDep.nextDep : sub.deps;
+	const nextDep = currentDep !== undefined
+		? currentDep.nextDep
+		: sub.deps;
 	if (nextDep !== undefined && nextDep.dep === dep) {
 		sub.depsTail = nextDep;
 		return nextDep;
@@ -83,7 +85,7 @@ function linkNewDep(
 	dep: Dependency,
 	sub: Subscriber,
 	nextDep: Link | undefined,
-	depsTail: Link | undefined,
+	depsTail: Link | undefined
 ): Link {
 	let newLink: Link;
 
@@ -140,7 +142,7 @@ export function propagate(subs: Link): void {
 				!(subFlags >> 2) ||
 				(subFlags & SubscriberFlags.Recursed &&
 					((sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag),
-					true))
+						true))
 			) {
 				const subSubs = (sub as Dependency).subs;
 				if (subSubs !== undefined) {
@@ -151,10 +153,9 @@ export function propagate(subs: Link): void {
 						++stack;
 					} else {
 						link = subSubs;
-						targetFlag =
-							'notify' in sub
-								? SubscriberFlags.InnerEffectsPending
-								: SubscriberFlags.ToCheckDirty;
+						targetFlag = 'notify' in sub
+							? SubscriberFlags.InnerEffectsPending
+							: SubscriberFlags.ToCheckDirty;
 					}
 					continue;
 				}
@@ -180,10 +181,9 @@ export function propagate(subs: Link): void {
 						++stack;
 					} else {
 						link = subSubs;
-						targetFlag =
-							'notify' in sub
-								? SubscriberFlags.InnerEffectsPending
-								: SubscriberFlags.ToCheckDirty;
+						targetFlag = 'notify' in sub
+							? SubscriberFlags.InnerEffectsPending
+							: SubscriberFlags.ToCheckDirty;
 					}
 					continue;
 				}
@@ -211,7 +211,9 @@ export function propagate(subs: Link): void {
 			break;
 		}
 		if (link !== subs) {
-			targetFlag = stack ? SubscriberFlags.ToCheckDirty : SubscriberFlags.Dirty;
+			targetFlag = stack
+				? SubscriberFlags.ToCheckDirty
+				: SubscriberFlags.Dirty;
 		}
 		link = subs = nextSub;
 	} while (true);
@@ -225,11 +227,7 @@ export function shallowPropagate(link: Link): void {
 	do {
 		const updateSub = link.sub;
 		const updateSubFlags = updateSub.flags;
-		if (
-			(updateSubFlags &
-				(SubscriberFlags.ToCheckDirty | SubscriberFlags.Dirty)) ===
-			SubscriberFlags.ToCheckDirty
-		) {
+		if ((updateSubFlags & (SubscriberFlags.ToCheckDirty | SubscriberFlags.Dirty)) === SubscriberFlags.ToCheckDirty) {
 			updateSub.flags = updateSubFlags | SubscriberFlags.Dirty;
 		}
 		link = link.nextSub!;

--- a/src/system.ts
+++ b/src/system.ts
@@ -135,9 +135,10 @@ export function propagate(subs: Link): void {
 			sub.flags = subFlags | targetFlag;
 			if (
 				!(subFlags >> 2) ||
-				(subFlags & SubscriberFlags.Recursed &&
-					((sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag),
-						true))
+				(
+					subFlags & SubscriberFlags.Recursed
+					&& ((sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag), true)
+				)
 			) {
 				const subSubs = (sub as Dependency).subs;
 				if (subSubs !== undefined) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -137,7 +137,7 @@ export function propagate(subs: Link): void {
 				!(subFlags >> 2) ||
 				(
 					subFlags & SubscriberFlags.Recursed
-					&& ((sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag), true)
+					&& (sub.flags = (subFlags & ~SubscriberFlags.Recursed) | targetFlag, true)
 				)
 			) {
 				const subSubs = (sub as Dependency).subs;


### PR DESCRIPTION
In propagate, It always takes:
```ts
sub.flags = subFlags | targetFlag
```

Therefore, https://github.com/stackblitz/alien-signals/blob/master/src/system.ts#L168 is an additional calculation.

example:
```js
var a = 1 << 1; // 2

console.log((a |= 1 << 1)); // 2
console.log((a |= 1 << 1)); // 2
```