### PR TITLE
refactor: avoid using `export * as` for tree-shaking friendly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,4 @@ export * from './effectScope.js';
 export * from './signal.js';
 export * from './system.js';
 export * from './types.js';
-export {
-	asyncCheckDirty as unstable_asyncCheckDirty,
-	asyncComputed as unstable_asyncComputed,
-	AsyncComputed as unstable_AsyncComputed,
-	asyncEffect as unstable_asyncEffect,
-	AsyncEffect as unstable_AsyncEffect,
-	computedArray as unstable_computedArray,
-	computedSet as unstable_computedSet,
-	EqualityComputed as unstable_EqualityComputed,
-	equalityComputed as unstable_equalityComputed,
-} from './unstable/index.js';
+export * from './unstable/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,14 @@ export * from './effectScope.js';
 export * from './signal.js';
 export * from './system.js';
 export * from './types.js';
-export * as unstable from './unstable/index.js';
-/**
- * @deprecated Use `unstable` instead.
- */
-export * as Unstable from './unstable/index.js';
+export {
+	asyncCheckDirty as unstable_asyncCheckDirty,
+	asyncComputed as unstable_asyncComputed,
+	AsyncComputed as unstable_AsyncComputed,
+	asyncEffect as unstable_asyncEffect,
+	AsyncEffect as unstable_AsyncEffect,
+	computedArray as unstable_computedArray,
+	computedSet as unstable_computedSet,
+	EqualityComputed as unstable_EqualityComputed,
+	equalityComputed as unstable_equalityComputed,
+} from './unstable/index.js';

--- a/src/unstable/index.ts
+++ b/src/unstable/index.ts
@@ -1,6 +1,29 @@
-export * from './asyncComputed.js';
-export * from './asyncEffect.js';
-export * from './asyncSystem.js';
-export * from './computedArray.js';
-export * from './computedSet.js';
-export * from './equalityComputed.js';
+
+import { AsyncComputed, asyncComputed } from './asyncComputed.js';
+import { AsyncEffect, asyncEffect } from './asyncEffect.js';
+import { asyncCheckDirty } from './asyncSystem.js';
+import { computedArray } from './computedArray.js';
+import { computedSet } from './computedSet.js';
+import { EqualityComputed, equalityComputed } from './equalityComputed.js';
+
+export const unstable: {
+	AsyncComputed: typeof AsyncComputed;
+	asyncComputed: typeof asyncComputed;
+	AsyncEffect: typeof AsyncEffect;
+	asyncEffect: typeof asyncEffect;
+	asyncCheckDirty: typeof asyncCheckDirty;
+	computedArray: typeof computedArray;
+	computedSet: typeof computedSet;
+	EqualityComputed: typeof EqualityComputed;
+	equalityComputed: typeof equalityComputed;
+} = {
+	AsyncComputed,
+	asyncComputed,
+	AsyncEffect,
+	asyncEffect,
+	asyncCheckDirty,
+	computedArray,
+	computedSet,
+	EqualityComputed,
+	equalityComputed,
+};


### PR DESCRIPTION
Shipping the unstable module as `export * as unstable from './unstable/index.js'` does not let this library be tree-shaken.

This PR re-exports all methods from unstable with an `unstable_` prefix, which makes it tree-shakeable once again, while only needing to replace one character(`[dot]` with `_` underscore)

Fixes #27 