### PR TITLE
refactor: no longer use activeTrackId, activeScopeTrackId

### DIFF
--- a/src/effectScope.ts
+++ b/src/effectScope.ts
@@ -1,23 +1,19 @@
-import { nextTrackId } from './effect.js';
 import { endTrack, runInnerEffects, Link, startTrack, Subscriber, SubscriberFlags } from './system.js';
 
 export let activeEffectScope: EffectScope | undefined = undefined;
-export let activeScopeTrackId = 0;
 
 export function untrackScope<T>(fn: () => T): T {
 	const prevSub = activeEffectScope;
-	const prevTrackId = activeScopeTrackId;
-	setActiveScope(undefined, 0);
+	setActiveScope(undefined);
 	try {
 		return fn();
 	} finally {
-		setActiveScope(prevSub, prevTrackId);
+		setActiveScope(prevSub);
 	}
 }
 
-export function setActiveScope(sub: EffectScope | undefined, trackId: number): void {
+export function setActiveScope(sub: EffectScope | undefined): void {
 	activeEffectScope = sub;
-	activeScopeTrackId = trackId;
 }
 
 export function effectScope(): EffectScope {
@@ -30,8 +26,6 @@ export class EffectScope implements Subscriber {
 	depsTail: Link | undefined = undefined;
 	flags: SubscriberFlags = SubscriberFlags.None;
 
-	trackId: number = nextTrackId();
-
 	notify(): void {
 		const flags = this.flags;
 		if (flags & SubscriberFlags.InnerEffectsPending) {
@@ -42,12 +36,11 @@ export class EffectScope implements Subscriber {
 
 	run<T>(fn: () => T): T {
 		const prevSub = activeEffectScope;
-		const prevTrackId = activeScopeTrackId;
-		setActiveScope(this, this.trackId);
+		setActiveScope(this);
 		try {
 			return fn();
 		} finally {
-			setActiveScope(prevSub, prevTrackId);
+			setActiveScope(prevSub);
 		}
 	}
 

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -1,4 +1,4 @@
-import { activeSub, activeTrackId } from './effect.js';
+import { activeSub } from './effect.js';
 import { Dependency, link, Link, propagate } from './system.js';
 import type { IWritableSignal } from './types.js';
 
@@ -12,16 +12,14 @@ export class Signal<T = any> implements Dependency, IWritableSignal<T> {
 	// Dependency
 	subs: Link | undefined = undefined;
 	subsTail: Link | undefined = undefined;
-	lastTrackedId = 0;
 
 	constructor(
 		public currentValue: T
 	) { }
 
 	get(): T {
-		if (activeTrackId && this.lastTrackedId !== activeTrackId) {
-			this.lastTrackedId = activeTrackId;
-			link(this, activeSub!);
+		if (activeSub !== undefined) {
+			link(this, activeSub);
 		}
 		return this.currentValue;
 	}

--- a/src/system.ts
+++ b/src/system.ts
@@ -337,7 +337,7 @@ export function checkDirty(link: Link): boolean {
 
 export function startTrack(sub: Subscriber): void {
 	sub.depsTail = undefined;
-	sub.flags = SubscriberFlags.Tracking;
+	sub.flags = (sub.flags & ~(SubscriberFlags.Recursed | SubscriberFlags.Notified)) | SubscriberFlags.Tracking;
 }
 
 export function endTrack(sub: Subscriber): void {
@@ -384,13 +384,9 @@ function clearTrack(link: Link): void {
 		linkPool = link;
 
 		if (dep.subs === undefined && 'deps' in dep) {
-			if ('notify' in dep) {
-				dep.flags = SubscriberFlags.None;
-			} else {
-				const depFlags = dep.flags;
-				if (!(depFlags & SubscriberFlags.Dirty)) {
-					dep.flags = depFlags | SubscriberFlags.Dirty;
-				}
+			const depFlags = dep.flags;
+			if (!(depFlags & SubscriberFlags.Dirty)) {
+				dep.flags = depFlags | SubscriberFlags.Dirty;
 			}
 			const depDeps = dep.deps;
 			if (depDeps !== undefined) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -71,15 +71,15 @@ function drainQueuedEffects(): void {
 
 export function link(dep: Dependency, sub: Subscriber): void {
 	const currentDep = sub.depsTail;
-	let nextDep: Link | undefined;
-	if (currentDep !== undefined) {
-		if (currentDep.dep === dep) {
-			return;
-		}
-		nextDep = currentDep.nextDep;
-	} else {
-		nextDep = sub.deps;
+	if (
+		currentDep !== undefined
+		&& currentDep.dep === dep
+	) {
+		return;
 	}
+	const nextDep = currentDep !== undefined
+		? currentDep.nextDep
+		: sub.deps;
 	if (
 		nextDep !== undefined
 		&& nextDep.dep === dep

--- a/src/unstable/asyncEffect.ts
+++ b/src/unstable/asyncEffect.ts
@@ -1,4 +1,4 @@
-import { Effect, nextTrackId } from '../effect.js';
+import { Effect } from '../effect.js';
 import { Dependency, endTrack, link, startTrack, SubscriberFlags } from '../system.js';
 import { asyncCheckDirty } from './asyncSystem.js';
 
@@ -40,15 +40,11 @@ export class AsyncEffect<T = any> extends Effect {
 	async run(): Promise<T> {
 		try {
 			startTrack(this);
-			const trackId = nextTrackId();
 			const generator = this.fn();
 			let current = await generator.next();
 			while (!current.done) {
 				const dep = current.value;
-				if (dep.lastTrackedId !== trackId) {
-					dep.lastTrackedId = trackId;
-					link(dep, this);
-				}
+				link(dep, this);
 				current = await generator.next();
 			}
 			return await current.value;


### PR DESCRIPTION
`activeTrackId` and `activeScopeTrackId` were originally designed to quickly skip unnecessary dynamic dependency updates. However, since dynamic dependencies are low-frequency events, using `isValidLink()` with a time complexity of O(n) instead and completely removing the `activeTrackId` and `activeScopeTrackId` logic actually results in generally much faster.

### Benchmark Results

#### main branch

Memory Usage: 2498.22 KB

| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `  1.40 µs/iter` | `  1.40 µs` | `  1.40 µs` | `  1.41 µs` | `  1.41 µs` |
| propagate: 1 * 10    | `  7.05 µs/iter` | `  7.04 µs` | `  7.05 µs` | `  7.05 µs` | `  7.05 µs` |
| propagate: 1 * 100   | ` 61.90 µs/iter` | ` 61.87 µs` | ` 61.91 µs` | ` 61.92 µs` | ` 61.97 µs` |
| propagate: 10 * 1    | ` 12.54 µs/iter` | ` 12.53 µs` | ` 12.55 µs` | ` 12.55 µs` | ` 12.55 µs` |
| propagate: 10 * 10   | ` 68.97 µs/iter` | ` 68.29 µs` | ` 68.92 µs` | ` 72.33 µs` | ` 91.08 µs` |
| propagate: 10 * 100  | `617.76 µs/iter` | `614.33 µs` | `618.88 µs` | `637.96 µs` | `652.67 µs` |
| propagate: 100 * 1   | `123.08 µs/iter` | `121.92 µs` | `122.79 µs` | `135.42 µs` | `148.25 µs` |
| propagate: 100 * 10  | `682.61 µs/iter` | `679.21 µs` | `684.00 µs` | `693.00 µs` | `724.08 µs` |
| propagate: 100 * 100 | `  6.16 ms/iter` | `  6.15 ms` | `  6.16 ms` | `  6.21 ms` | `  6.21 ms` |

#### This PR

Memory Usage: 2413.55 KB

| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `  1.28 µs/iter` | `  1.27 µs` | `  1.28 µs` | `  1.29 µs` | `  1.30 µs` |
| propagate: 1 * 10    | `  6.25 µs/iter` | `  6.24 µs` | `  6.25 µs` | `  6.25 µs` | `  6.26 µs` |
| propagate: 1 * 100   | ` 54.46 µs/iter` | ` 54.39 µs` | ` 54.49 µs` | ` 54.57 µs` | ` 54.59 µs` |
| propagate: 10 * 1    | ` 11.24 µs/iter` | ` 11.24 µs` | ` 11.24 µs` | ` 11.24 µs` | ` 11.25 µs` |
| propagate: 10 * 10   | ` 60.63 µs/iter` | ` 60.60 µs` | ` 60.64 µs` | ` 60.66 µs` | ` 60.69 µs` |
| propagate: 10 * 100  | `546.65 µs/iter` | `543.54 µs` | `548.00 µs` | `561.58 µs` | `570.88 µs` |
| propagate: 100 * 1   | `109.85 µs/iter` | `108.58 µs` | `109.67 µs` | `118.63 µs` | `152.00 µs` |
| propagate: 100 * 10  | `605.66 µs/iter` | `602.33 µs` | `607.04 µs` | `618.83 µs` | `629.33 µs` |
| propagate: 100 * 100 | `  5.44 ms/iter` | `  5.43 ms` | `  5.44 ms` | `  5.47 ms` | `  5.47 ms` |