### PR TITLE
refactor: remove nextNotify field

### DIFF
--- a/benchs/memoryUsage.mjs
+++ b/benchs/memoryUsage.mjs
@@ -27,3 +27,25 @@ globalThis.gc();
 end = process.memoryUsage().heapUsed;
 
 console.log(`effect: ${((end - start) / 1024).toFixed(2)} KB`);
+
+start = end;
+
+const w = 100;
+const h = 100;
+const src = signal(1);
+
+for (let i = 0; i < w; i++) {
+	let last = src;
+	for (let j = 0; j < h; j++) {
+		const prev = last;
+		last = computed(() => prev.get() + 1);
+	}
+	effect(() => last.get());
+}
+
+src.set(src.get() + 1);
+
+globalThis.gc();
+end = process.memoryUsage().heapUsed;
+
+console.log(`tree: ${((end - start) / 1024).toFixed(2)} KB`);

--- a/benchs/memoryUsage.mjs
+++ b/benchs/memoryUsage.mjs
@@ -39,8 +39,8 @@ for (let i = 0; i < w; i++) {
 	for (let j = 0; j < h; j++) {
 		const prev = last;
 		last = computed(() => prev.get() + 1);
+		effect(() => last.get());
 	}
-	effect(() => last.get());
 }
 
 src.set(src.get() + 1);

--- a/benchs/memoryUsage.mjs
+++ b/benchs/memoryUsage.mjs
@@ -1,23 +1,29 @@
 import { computed, effect, signal } from '../esm/index.mjs';
 
 globalThis.gc();
-const start = process.memoryUsage().heapUsed;
+let start = process.memoryUsage().heapUsed;
 
-const w = 100;
-const h = 100;
-const src = signal(1);
-
-for (let i = 0; i < w; i++) {
-	let last = src;
-	for (let j = 0; j < h; j++) {
-		const prev = last;
-		last = computed(() => prev.get() + 1);
-	}
-	effect(() => last.get());
-}
-
-src.set(src.get() + 1);
+const signals = Array.from({ length: 10000 }, () => signal(0));
 
 globalThis.gc();
-const end = process.memoryUsage().heapUsed;
-console.log(`Memory Usage: ${((end - start) / 1024).toFixed(2)} KB`);
+let end = process.memoryUsage().heapUsed;
+
+console.log(`signal: ${((end - start) / 1024).toFixed(2)} KB`);
+
+start = end;
+
+const computeds = Array.from({ length: 10000 }, (_, i) => computed(() => signals[i].get() + 1));
+
+globalThis.gc();
+end = process.memoryUsage().heapUsed;
+
+console.log(`computed: ${((end - start) / 1024).toFixed(2)} KB`);
+
+start = end;
+
+Array.from({ length: 10000 }, (_, i) => effect(() => computeds[i].get()));
+
+globalThis.gc();
+end = process.memoryUsage().heapUsed;
+
+console.log(`effect: ${((end - start) / 1024).toFixed(2)} KB`);

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -24,8 +24,6 @@ export function effect<T>(fn: () => T): Effect<T> {
 }
 
 export class Effect<T = any> implements IEffect, IDependency {
-	nextNotify: IEffect | undefined = undefined;
-
 	// Dependency
 	subs: ILink | undefined = undefined;
 	subsTail: ILink | undefined = undefined;


### PR DESCRIPTION
Use `depsTail.nextDep` instead of `nextNotify`, which aims to reduce the memory footprint of effects.

Vue test suite passed. ✅

### Benchmark Results

#### main branch

signal: 548.91 KB
computed: 2148.55 KB
effect: 3002.95 KB
tree: 4353.23 KB

#### This PR

signal: 548.91 KB
computed: 2148.55 KB
effect: 2926.23 KB
tree: 4272.50 KB