### PR TITLE
test: import glitch avoidance tests from preact-signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"esbuild": "latest",
 		"mitata": "latest",
 		"typescript": "latest",
-		"vitest": "latest"
+		"vitest": "latest",
+		"jest-extended": "latest"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       esbuild:
         specifier: latest
         version: 0.24.0
+      jest-extended:
+        specifier: latest
+        version: 4.0.2
       mitata:
         specifier: latest
         version: 1.0.15
@@ -305,6 +308,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
@@ -388,6 +395,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -421,6 +431,14 @@ packages:
   '@vitest/utils@2.1.2':
     resolution: {integrity: sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -433,9 +451,20 @@ packages:
     resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
     engines: {node: '>=12'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -449,6 +478,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -470,6 +503,27 @@ packages:
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-extended@4.0.2:
+    resolution: {integrity: sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      jest: '>=27.2.5'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
@@ -502,6 +556,13 @@ packages:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   rollup@4.24.0:
     resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -519,6 +580,10 @@ packages:
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -752,6 +817,10 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
@@ -802,6 +871,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@types/estree@1.0.6': {}
 
   '@vitest/expect@2.1.2':
@@ -844,6 +915,12 @@ snapshots:
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
   assertion-error@2.0.1: {}
 
   cac@6.7.14: {}
@@ -856,13 +933,26 @@ snapshots:
       loupe: 3.1.1
       pathval: 2.0.0
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   check-error@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  diff-sequences@29.6.3: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -926,6 +1016,22 @@ snapshots:
 
   get-func-name@2.0.2: {}
 
+  has-flag@4.0.0: {}
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-extended@4.0.2:
+    dependencies:
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+
+  jest-get-type@29.6.3: {}
+
   loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
@@ -951,6 +1057,14 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.1.0
       source-map-js: 1.2.1
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  react-is@18.3.1: {}
 
   rollup@4.24.0:
     dependencies:
@@ -981,6 +1095,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.7.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tinybench@2.9.0: {}
 

--- a/tests/topology.spec.ts
+++ b/tests/topology.spec.ts
@@ -1,0 +1,388 @@
+import { expect, test, vi, describe } from 'vitest';
+import {computed, effect, signal} from '../src';
+
+// To give access to .toHaveBeenCalledBefore()
+import * as matchers from 'jest-extended';
+
+expect.extend(matchers);
+
+/** Tests adopted with thanks from preact-signals implementation at
+ * https://github.com/preactjs/signals/blob/main/packages/core/test/signal.test.tsx
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-present Preact Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE
+ */
+
+describe("graph updates", () => {
+
+    test('should drop A->B->A updates', () => {
+        //     A
+        //   / |
+        //  B  | <- Looks like a flag doesn't it? :D
+        //   \ |
+        //     C
+        //     |
+        //     D
+        const a = signal(2);
+
+        const b = computed(() => a() - 1);
+        const c = computed(() => a() + b());
+
+        const compute = vi.fn(() => "d: " + c());
+        const d = computed(compute);
+
+        // Trigger read
+        expect(d()).toBe("d: 3");
+        expect(compute).toHaveBeenCalledOnce();
+        compute.mockClear();
+
+        a(4);
+        d();
+        expect(compute).toHaveBeenCalledOnce();
+    });
+
+    test('should only update every signal once (diamond graph)', () => {
+        // In this scenario "D" should only update once when "A" receives
+        // an update. This is sometimes referred to as the "diamond" scenario.
+        //     A
+        //   /   \
+        //  B     C
+        //   \   /
+        //     D
+
+        const a = signal("a");
+        const b = computed(() => a());
+        const c = computed(() => a());
+
+        const spy = vi.fn(() => b() + " " + c());
+        const d = computed(spy);
+
+        expect(d()).toBe("a a");
+        expect(spy).toHaveBeenCalledOnce();
+
+        a("aa");
+        expect(d()).toBe("aa aa");
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    test('should only update every signal once (diamond graph + tail)', () => {
+        // "E" will be likely updated twice if our mark+sweep logic is buggy.
+        //     A
+        //   /   \
+        //  B     C
+        //   \   /
+        //     D
+        //     |
+        //     E
+
+        const a = signal("a");
+        const b = computed(() => a());
+        const c = computed(() => a());
+
+        const d = computed(() => b() + " " + c());
+
+        const spy = vi.fn(() => d());
+        const e = computed(spy);
+
+        expect(e()).toBe("a a");
+        expect(spy).toHaveBeenCalledOnce();
+
+        a("aa");
+        expect(e()).toBe("aa aa");
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    test('should bail out if result is the same', () => {
+        // Bail out if value of "B" never changes
+        // A->B->C
+        const a = signal("a");
+        const b = computed(() => {
+            a();
+            return "foo";
+        });
+
+        const spy = vi.fn(() => b());
+        const c = computed(spy);
+
+        expect(c()).toBe("foo");
+        expect(spy).toHaveBeenCalledOnce();
+
+        a("aa");
+        expect(c()).toBe("foo");
+        expect(spy).toHaveBeenCalledOnce();
+    });
+
+    test('should only update every signal once (jagged diamond graph + tails)', () => {
+        // "F" and "G" will be likely updated twice if our mark+sweep logic is buggy.
+        //     A
+        //   /   \
+        //  B     C
+        //  |     |
+        //  |     D
+        //   \   /
+        //     E
+        //   /   \
+        //  F     G
+        const a = signal("a");
+
+        const b = computed(() => a());
+        const c = computed(() => a());
+
+        const d = computed(() => c());
+
+        const eSpy = vi.fn(() => b() + " " + d());
+        const e = computed(eSpy);
+
+        const fSpy = vi.fn(() => e());
+        const f = computed(fSpy);
+        const gSpy = vi.fn(() => e());
+        const g = computed(gSpy);
+
+        expect(f()).toBe("a a");
+        expect(fSpy).toHaveBeenCalledTimes(1);
+
+        expect(g()).toBe("a a");
+        expect(gSpy).toHaveBeenCalledTimes(1);
+
+        eSpy.mockClear();
+        fSpy.mockClear();
+        gSpy.mockClear();
+
+        a("b");
+
+        expect(e()).toBe("b b");
+        expect(eSpy).toHaveBeenCalledTimes(1);
+
+        expect(f()).toBe("b b");
+        expect(fSpy).toHaveBeenCalledTimes(1);
+
+        expect(g()).toBe("b b");
+        expect(gSpy).toHaveBeenCalledTimes(1);
+
+        eSpy.mockClear();
+        fSpy.mockClear();
+        gSpy.mockClear();
+
+        a("c");
+
+        expect(e()).toBe("c c");
+        expect(eSpy).toHaveBeenCalledTimes(1);
+
+        expect(f()).toBe("c c");
+        expect(fSpy).toHaveBeenCalledTimes(1);
+
+        expect(g()).toBe("c c");
+        expect(gSpy).toHaveBeenCalledTimes(1);
+
+        // top to bottom
+        expect(eSpy).toHaveBeenCalledBefore(fSpy);
+        // left to right
+        expect(fSpy).toHaveBeenCalledBefore(gSpy);
+    });
+
+    test('should only subscribe to signals listened to', () => {
+        //    *A
+        //   /   \
+        // *B     C <- we don't listen to C
+        const a = signal("a");
+
+        const b = computed(() => a());
+        const spy = vi.fn(() => a());
+        computed(spy);
+
+        expect(b()).toBe("a");
+        expect(spy).not.toHaveBeenCalled();
+
+        a("aa");
+        expect(b()).toBe("aa");
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('should only subscribe to signals listened to II', () => {
+        // Here both "B" and "C" are active in the beginning, but
+        // "B" becomes inactive later. At that point it should
+        // not receive any updates anymore.
+        //    *A
+        //   /   \
+        // *B     D <- we don't listen to C
+        //  |
+        // *C
+        const a = signal("a");
+        const spyB = vi.fn(() => a());
+        const b = computed(spyB);
+
+        const spyC = vi.fn(() => b());
+        const c = computed(spyC);
+
+        const d = computed(() => a());
+
+        let result = "";
+        const unsub = effect(() => {
+            result = c();
+        });
+
+        expect(result).toBe("a");
+        expect(d()).toBe("a");
+
+        spyB.mockClear();
+        spyC.mockClear();
+        unsub();
+
+        a("aa");
+
+        expect(spyB).not.toHaveBeenCalled();
+        expect(spyC).not.toHaveBeenCalled();
+        expect(d()).toBe("aa");
+    });
+
+    test('should ensure subs update even if one dep unmarks it', () => {
+        // In this scenario "C" always returns the same value. When "A"
+        // changes, "B" will update, then "C" at which point its update
+        // to "D" will be unmarked. But "D" must still update because
+        // "B" marked it. If "D" isn't updated, then we have a bug.
+        //     A
+        //   /   \
+        //  B     *C <- returns same value every time
+        //   \   /
+        //     D
+        const a = signal("a");
+        const b = computed(() => a());
+        const c = computed(() => {
+            a();
+            return "c";
+        });
+        const spy = vi.fn(() => b() + " " + c());
+        const d = computed(spy);
+
+        expect(d()).toBe("a c");
+        spy.mockClear();
+
+        a("aa");
+        d();
+        expect(spy).toHaveReturnedWith("aa c");
+    });
+
+    test('should ensure subs update even if two deps unmark it', () => {
+        // In this scenario both "C" and "D" always return the same
+        // value. But "E" must still update because "A" marked it.
+        // If "E" isn't updated, then we have a bug.
+        //     A
+        //   / | \
+        //  B *C *D
+        //   \ | /
+        //     E
+        const a = signal("a");
+        const b = computed(() => a());
+        const c = computed(() => {
+            a();
+            return "c";
+        });
+        const d = computed(() => {
+            a();
+            return "d";
+        });
+        const spy = vi.fn(() => b() + " " + c() + " " + d());
+        const e = computed(spy);
+
+        expect(e()).toBe("a c d");
+        spy.mockClear();
+
+        a("aa");
+        e();
+        expect(spy).toHaveReturnedWith("aa c d");
+    });
+
+    test('should support lazy branches', () => {
+        const a = signal(0);
+        const b = computed(() => a());
+        const c = computed(() => (a() > 0 ? a() : b()));
+
+        expect(c()).toBe(0);
+        a(1);
+        expect(c()).toBe(1);
+
+        a(0);
+        expect(c()).toBe(0);
+    });
+
+    test('should not update a sub if all deps unmark it', () => {
+        // In this scenario "B" and "C" always return the same value. When "A"
+        // changes, "D" should not update.
+        //     A
+        //   /   \
+        // *B     *C
+        //   \   /
+        //     D
+        const a = signal("a");
+        const b = computed(() => {
+            a();
+            return "b";
+        });
+        const c = computed(() => {
+            a();
+            return "c";
+        });
+        const spy = vi.fn(() => b() + " " + c());
+        const d = computed(spy);
+
+        expect(d()).toBe("b c");
+        spy.mockClear();
+
+        a("aa");
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+});
+
+describe("error handling", () => {
+
+    test('should keep graph consistent on errors during activation', () => {
+        const a = signal(0);
+        const b = computed(() => {
+            throw new Error("fail");
+        });
+        const c = computed(() => a());
+
+        expect(() => b()).toThrow("fail");
+
+        a(1);
+        expect(c()).toBe(1);
+    });
+
+    test('should keep graph consistent on errors in computeds', () => {
+        const a = signal(0);
+        const b = computed(() => {
+            if (a() === 1) throw new Error("fail");
+            return a();
+        });
+        const c = computed(() => b());
+
+        expect(c()).toBe(0);
+
+        a(1);
+        expect(() => b()).toThrow("fail");
+
+        a(2);
+        expect(c()).toBe(2);
+    });
+
+});


### PR DESCRIPTION
Resolves #37

I've imported the tests I'm interested in but could grab a few more from https://github.com/preactjs/signals/blob/main/packages/core/test/signal.test.tsx if it would help - we could grab "effect", "batch" and "computed" most of which are relevant