### PR TITLE
refactor: remove `subs` property from Dependency interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,6 @@ export function signal<T>(oldValue: T): WriteableSignal<T>;
 export function signal<T>(oldValue?: T): WriteableSignal<T | undefined> {
 	return signalGetterSetter.bind({
 		currentValue: oldValue,
-		subs: undefined,
 		subsTail: undefined,
 	}) as WriteableSignal<T | undefined>;
 }
@@ -97,7 +96,6 @@ export function signal<T>(oldValue?: T): WriteableSignal<T | undefined> {
 export function computed<T>(getter: (cachedValue?: T) => T): () => T {
 	return computedGetter.bind({
 		currentValue: undefined,
-		subs: undefined,
 		subsTail: undefined,
 		deps: undefined,
 		depsTail: undefined,
@@ -109,7 +107,6 @@ export function computed<T>(getter: (cachedValue?: T) => T): () => T {
 export function effect<T>(fn: () => T): () => void {
 	const e: Effect = {
 		fn,
-		subs: undefined,
 		subsTail: undefined,
 		deps: undefined,
 		depsTail: undefined,
@@ -201,7 +198,7 @@ function computedGetter<T>(this: Computed<T>): T {
 function signalGetterSetter<T>(this: Signal<T>, ...value: [T]): T | void {
 	if (value.length) {
 		if (this.currentValue !== (this.currentValue = value[0])) {
-			const subs = this.subs;
+			const subs = this.subsTail;
 			if (subs !== undefined) {
 				propagate(subs);
 				if (!batchDepth) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,9 +198,9 @@ function computedGetter<T>(this: Computed<T>): T {
 function signalGetterSetter<T>(this: Signal<T>, ...value: [T]): T | void {
 	if (value.length) {
 		if (this.currentValue !== (this.currentValue = value[0])) {
-			const subs = this.subsTail;
-			if (subs !== undefined) {
-				propagate(subs);
+			const subsTail = this.subsTail;
+			if (subsTail !== undefined) {
+				propagate(subsTail);
 				if (!batchDepth) {
 					processEffectNotifications();
 				}

--- a/src/system.ts
+++ b/src/system.ts
@@ -11,9 +11,9 @@ export interface Subscriber {
 export interface Link {
 	dep: Dependency | (Dependency & Subscriber);
 	sub: Subscriber | (Dependency & Subscriber);
-	// Reused to link the previous stack in updateDirtyFlag
-	// Reused to link the previous stack in propagate
 	prevSub: Link | undefined;
+	// Reused to link the previous stack in checkDirty
+	// Reused to link the previous stack in propagate
 	nextSub: Link | undefined;
 	// Reused to link the notify effect in queuedEffects
 	nextDep: Link | undefined;


### PR DESCRIPTION
Removed `Dependency.subs` property to reduce memory usage. The `propagate`, `shallowPropagate` functions need to be modified to start the loop from subs tail instead of subs head.

#### Memory usage

before:

```
signal: 1016.52 KB
computed: 2615.49 KB
effect: 2940.61 KB
tree: 4721.33 KB
```

after:

```
signal: 938.17 KB
computed: 2537.10 KB
effect: 2861.38 KB
tree: 4565.70 KB
```