### PR TITLE
test: update unit tests for effectScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ console.log(doubleCount()); // 4
 #### Effect Scope
 
 ```ts
-import { signal, effectScope } from 'alien-signals';
+import { signal, effect, effectScope } from 'alien-signals';
 
 const count = signal(1);
 

--- a/tests/effectScope.spec.ts
+++ b/tests/effectScope.spec.ts
@@ -12,12 +12,14 @@ test('should not trigger after stop', () => {
 			triggers++;
 			count();
 		});
+
+		count(2)
 	});
 
-	expect(triggers).toBe(1);
-	count(2);
 	expect(triggers).toBe(2);
-	stopScope();
 	count(3);
-	expect(triggers).toBe(2);
+	expect(triggers).toBe(3);
+	stopScope();
+	count(4);
+	expect(triggers).toBe(3);
 });


### PR DESCRIPTION
## Issue
#52 

## Feat(test)
update unit tests for effectScope & readme example import

## WIP: debugging
I found that it works fine after removing `startTracking` of `effectScope`. It seems that the `SubscriberFlags.Tracking` tag affects the judgment inside `propagate`, resulting in incorrect judgment of `queuedEffects`? 
As a newcomer to the codebase, I’m hesitant to remove `startTracking()` from `effectScope` without deeper understanding, fearing that there will be other potential impacts.
