### PR TITLE
refactor: optimize flags handling in `startTracking` function

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -200,7 +200,7 @@ export function createReactiveSystem({
 	 */
 	function startTracking(sub: Subscriber): void {
 		sub.depsTail = undefined;
-		sub.flags = (sub.flags & ~(SubscriberFlags.Notified | SubscriberFlags.Recursed | SubscriberFlags.Propagated)) | SubscriberFlags.Tracking;
+		sub.flags = (sub.flags & (SubscriberFlags.Computed | SubscriberFlags.Effect)) | SubscriberFlags.Tracking;
 	}
 
 	/**


### PR DESCRIPTION
Attempting a shorter equivalent that specifies which flags to preserve, rather than which to clear.

The compiled code changes from `sub.flags=sub.flags&~(8|16|224)|4` to `sub.flags=sub.flags&(1|2)|4`, resulting in a tiny bundle size reduction (lol).