### PR TITLE
refactor: eliminate `notify` recursion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,16 +203,19 @@ function updateSignal(s: Signal, value: any): boolean {
 }
 
 function notify(e: Effect | EffectScope) {
-	const flags = e.flags;
-	if (!(flags & EffectFlags.Queued)) {
-		e.flags = flags | EffectFlags.Queued;
-		const subs = e.subs;
-		if (subs !== undefined) {
-			notify(subs.sub as Effect | EffectScope);
-		} else {
+	do {
+		const flags = e.flags;
+		if (!(flags & EffectFlags.Queued)) {
+			e.flags = flags | EffectFlags.Queued;
+			const subs = e.subs;
+			if (subs) {
+				e = subs.sub as Effect | EffectScope;
+				continue;
+			}
 			queuedEffects[queuedEffectsLength++] = e;
 		}
-	}
+		break;
+	} while (e !== undefined)
 }
 
 function run(e: Effect | EffectScope, flags: ReactiveFlags): void {


### PR DESCRIPTION
```
clk: ~0.05 GHz
cpu: Apple M3 Max
runtime: node 23.9.0 (arm64-darwin)
```

Before:
| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `946.52 ns/iter` | `921.31 ns` | `951.22 ns` | `967.06 ns` | `972.19 ns` |
| propagate: 1 * 10    | `  4.09 µs/iter` | `  4.03 µs` | `  4.09 µs` | `  4.30 µs` | `  4.30 µs` |
| propagate: 1 * 100   | ` 34.57 µs/iter` | ` 34.18 µs` | ` 34.63 µs` | ` 34.66 µs` | ` 34.86 µs` |
| propagate: 10 * 1    | `  7.20 µs/iter` | `  7.19 µs` | `  7.22 µs` | `  7.22 µs` | `  7.23 µs` |
| propagate: 10 * 10   | ` 38.08 µs/iter` | ` 37.57 µs` | ` 38.21 µs` | ` 38.25 µs` | ` 38.26 µs` |
| propagate: 10 * 100  | `346.01 µs/iter` | `321.71 µs` | `347.13 µs` | `368.67 µs` | `467.71 µs` |
| propagate: 100 * 1   | ` 69.05 µs/iter` | ` 63.63 µs` | ` 68.46 µs` | ` 83.42 µs` | ` 89.92 µs` |
| propagate: 100 * 10  | `384.42 µs/iter` | `359.38 µs` | `385.75 µs` | `416.67 µs` | `428.29 µs` |
| propagate: 100 * 100 | `  3.44 ms/iter` | `  3.41 ms` | `  3.44 ms` | `  3.48 ms` | `  3.49 ms` |
```
signal: 1173.70 KB
computed: 2620.52 KB
effect: 3091.95 KB
tree: 5029.80 KB
```

After:
| benchmark            |              avg |         min |         p75 |         p99 |         max |
| -------------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| propagate: 1 * 1     | `948.87 ns/iter` | `930.30 ns` | `952.74 ns` | `974.88 ns` | `977.20 ns` |
| propagate: 1 * 10    | `  4.07 µs/iter` | `  4.03 µs` | `  4.08 µs` | `  4.11 µs` | `  4.12 µs` |
| propagate: 1 * 100   | ` 34.46 µs/iter` | ` 34.25 µs` | ` 34.55 µs` | ` 34.66 µs` | ` 34.73 µs` |
| propagate: 10 * 1    | `  7.24 µs/iter` | `  7.20 µs` | `  7.25 µs` | `  7.27 µs` | `  7.28 µs` |
| propagate: 10 * 10   | ` 38.07 µs/iter` | ` 37.98 µs` | ` 38.12 µs` | ` 38.14 µs` | ` 38.18 µs` |
| propagate: 10 * 100  | `345.86 µs/iter` | `322.67 µs` | `346.63 µs` | `364.63 µs` | `491.71 µs` |
| propagate: 100 * 1   | ` 69.11 µs/iter` | ` 63.96 µs` | ` 69.08 µs` | ` 76.96 µs` | `102.71 µs` |
| propagate: 100 * 10  | `381.57 µs/iter` | `356.21 µs` | `382.00 µs` | `399.13 µs` | `418.54 µs` |
| propagate: 100 * 100 | `  3.42 ms/iter` | `  3.39 ms` | `  3.43 ms` | `  3.46 ms` | `  3.48 ms` |
```
signal: 1173.70 KB
computed: 2620.52 KB
effect: 3091.95 KB
tree: 5026.55 KB
```

---

The performance change is minimal, because the error of each device run needs to be taken into account, so it is concluded that this has no impact on performance. But it will be slightly better if there are many nodes. (Still negligible)

In terms of memory usage, `tree` has been reduced.