### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/src/system.ts
+++ b/src/system.ts
@@ -223,9 +223,12 @@ export function createReactiveSystem({
 				continue;
 			}
 
-			if (!dirty && link.nextDep !== undefined) {
-				link = link.nextDep;
-				continue;
+			if (!dirty) {
+				const nextDep = link.nextDep;
+				if (nextDep !== undefined) {
+					link = nextDep;
+					continue;
+				}
 			}
 
 			while (checkDepth) {


### PR DESCRIPTION
* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/dependabot)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the `dependabot.yml` file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

Will generate a PR to upgrade GitHub Actions in `.github/workflows/test.yml`:
```diff
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
```