### PR TITLE
Add documentation section about nested effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ count(3); // No console output
 
 #### Nested Effects
 
-Effects can be nested inside other effects. When the outer effect re-runs, inner effects from the previous run are automatically cleaned up, and new inner effects are created if needed. The system ensures proper execution order—outer effects always run before their inner effects:
+Effects can be nested inside other effects. When the outer effect re-runs, inner effects from the previous run are automatically cleaned up, and new inner effects are created if needed. The system ensures proper execution order, outer effects always run before their inner effects:
 
 ```ts
 import { signal, effect } from 'alien-signals';


### PR DESCRIPTION
This PR adds a section explaining nested effects behavior, which can be unexpected, especially for library authors.

For example, if a user conditionally runs library code inside an effect, all effects created within that library code will be cleaned up when the outer effect re-runs. While this can be intentional, it's not allways desired.

I runned into this problem with my library [@lilian1315/create-element](https://github.com/lilian1315/create-element) that allow to create reactive HTML elements with signals.