### PR TITLE
chore(readme): add ilha to adoption section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ I spent considerable time [optimizing Vue 3.4’s reactivity system](https://git
 - [gn8-ai/universe-alien-signals](https://github.com/gn8-ai/universe-alien-signals): Enables simple use of the Alien Signals state management system in modern frontend frameworks
 - [WebReflection/alien-signals](https://github.com/WebReflection/alien-signals): Preact signals like API and a class based approach for easy brand check
 - [@lift-html/alien](https://github.com/JLarky/lift-html/tree/main/packages/alien): Integrating alien-signals into lift-html
+- [ilha](https://github.com/ilhajs/ilha): A tiny web UI library built around the islands architecture
 
 ## Adoption
 


### PR DESCRIPTION
Adds [ilha](https://ilha.build) to the Adoption section of README. Ilha's whole reactivity is based on alien-signals.