### PR TITLE
fix: make effectScope participate in propagation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { createReactiveSystem, ReactiveFlags, type ReactiveNode } from './system.js';
 
+interface EffectScopeNode extends ReactiveNode {
+}
+
 interface EffectNode extends ReactiveNode {
 	fn(): void;
 }
@@ -28,12 +31,15 @@ const {
 	checkDirty,
 	shallowPropagate,
 } = createReactiveSystem({
-	update(node: SignalNode | ComputedNode): boolean {
-		if (node.depsTail !== undefined) {
-			return updateComputed(node as ComputedNode);
-		} else {
-			return updateSignal(node as SignalNode);
+	update(node: SignalNode | ComputedNode | EffectScopeNode): boolean {
+		if ('getter' in node) {
+			return updateComputed(node);
 		}
+		if ('currentValue' in node) {
+			return updateSignal(node);
+		}
+		node.flags = ReactiveFlags.Mutable;
+		return true;
 	},
 	notify(effect: EffectNode) {
 		let insertIndex = queuedLength;
@@ -163,12 +169,12 @@ export function effect(fn: () => void): () => void {
 }
 
 export function effectScope(fn: () => void): () => void {
-	const e: ReactiveNode = {
+	const e: EffectScopeNode = {
 		deps: undefined,
 		depsTail: undefined,
 		subs: undefined,
 		subsTail: undefined,
-		flags: ReactiveFlags.None,
+		flags: ReactiveFlags.Mutable,
 	};
 	const prevSub = setActiveSub(e);
 	if (prevSub !== undefined) {
@@ -329,13 +335,9 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T]): T | void {
 				}
 			}
 		}
-		let sub = activeSub;
-		while (sub !== undefined) {
-			if (sub.flags & (ReactiveFlags.Mutable | ReactiveFlags.Watching)) {
-				link(this, sub, cycle);
-				break;
-			}
-			sub = sub.subs?.sub;
+		const sub = activeSub;
+		if (sub !== undefined) {
+			link(this, sub, cycle);
 		}
 		return this.currentValue;
 	}
@@ -345,7 +347,7 @@ function effectOper(this: EffectNode): void {
 	effectScopeOper.call(this);
 }
 
-function effectScopeOper(this: ReactiveNode): void {
+function effectScopeOper(this: EffectScopeNode): void {
 	this.depsTail = undefined;
 	this.flags = ReactiveFlags.None;
 	purgeDeps(this);

--- a/tests/issue_105.spec.ts
+++ b/tests/issue_105.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'vitest';
+import { computed, effect, effectScope, signal, trigger } from '../src';
+
+test('#105 signal and computed should link to the same node in effectScope', () => {
+	const a = signal(0);
+	const b = computed(() => 0);
+	let triggers = 0;
+
+	effect(() => {
+		triggers += 1;
+		effectScope(() => {
+			effectScope(() => {
+				a();
+				b();
+			});
+		});
+	});
+
+	expect(triggers).toBe(1);
+	a(a() + 1);
+	expect(triggers).toBe(2);
+	trigger(b);
+	expect(triggers).toBe(3);
+});
+
+test('#105 effect should respond to both signal and computed changes through scope', () => {
+	const s = signal(0);
+	const c = computed(() => s() * 2);
+	let triggers = 0;
+
+	effect(() => {
+		triggers += 1;
+		effectScope(() => {
+			s();
+			c();
+		});
+	});
+
+	expect(triggers).toBe(1);
+
+	s(1);
+	expect(triggers).toBe(2);
+
+	trigger(c);
+	expect(triggers).toBe(3);
+});
+
+test('#105 scope should respond to consecutive signal updates', () => {
+	const s = signal(0);
+	let triggers = 0;
+
+	effect(() => {
+		triggers += 1;
+		effectScope(() => {
+			s();
+		});
+	});
+
+	expect(triggers).toBe(1);
+	s(1);
+	expect(triggers).toBe(2);
+	s(2);
+	expect(triggers).toBe(3);
+});
+
+test('#105 computed in standalone scope should cache and clean up', () => {
+	const s = signal(0);
+	let computeCount = 0;
+
+	const dispose = effectScope(() => {
+		const c = computed(() => {
+			computeCount++;
+			return s();
+		});
+		expect(c()).toBe(0);
+		expect(c()).toBe(0);
+	});
+
+	// Computed should cache (only 1 evaluation, not 2)
+	expect(computeCount).toBe(1);
+
+	dispose();
+});


### PR DESCRIPTION
## Summary

Fixes #105 — signals and computeds linked to different nodes when called in the same effectScope.

**Root cause:** Signals walked up the `sub.subs?.sub` chain to find a node with `Mutable|Watching` flags (the parent effect), bypassing inert scope nodes (`flags=None`). Computeds linked directly to `activeSub` (the scope). This inconsistency meant the parent effect could respond to signal changes but not computed changes through the scope.

**Fix (3 changes):**
- Give `effectScope` the `Mutable` flag so it participates in dirty propagation
- Remove the signal walk-up — both signal and computed now link to `activeSub` directly
- Handle scope nodes in the `update` callback (clear flags, return `true`)

## Test plan
- Added 4 tests in `tests/issue_105.spec.ts` covering:
  - [x] Signal and computed link to the same node in nested effectScopes
  - [x] Effect responds to both signal and computed changes through scope
  - [x] Scope responds to consecutive signal updates
  - [x] Computed caching works in standalone scope
- All 56 existing tests pass