### PR TITLE
fix: prevent inner write from blocking future propagation through computed chain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ interface SignalNode<T = any> extends ReactiveNode {
 }
 
 let cycle = 0;
+let runDepth = 0;
 let batchDepth = 0;
 let notifyIndex = 0;
 let queuedLength = 0;
@@ -160,8 +161,10 @@ export function effect(fn: () => void): () => void {
 		link(e, prevSub, 0);
 	}
 	try {
+		++runDepth;
 		e.fn();
 	} finally {
+		--runDepth;
 		activeSub = prevSub;
 		e.flags &= ~ReactiveFlags.RecursedCheck;
 	}
@@ -206,7 +209,7 @@ export function trigger(fn: () => void) {
 			link = unlink(link, sub);
 			const subs = dep.subs;
 			if (subs !== undefined) {
-				propagate(subs);
+				propagate(subs, !!runDepth);
 				shallowPropagate(subs);
 			}
 		}
@@ -217,14 +220,16 @@ export function trigger(fn: () => void) {
 }
 
 function updateComputed(c: ComputedNode): boolean {
-	++cycle;
 	c.depsTail = undefined;
 	c.flags = ReactiveFlags.Mutable | ReactiveFlags.RecursedCheck;
 	const prevSub = setActiveSub(c);
 	try {
+		++cycle;
+		++runDepth;
 		const oldValue = c.value;
 		return oldValue !== (c.value = c.getter(oldValue));
 	} finally {
+		--runDepth;
 		activeSub = prevSub;
 		c.flags &= ~ReactiveFlags.RecursedCheck;
 		purgeDeps(c);
@@ -245,13 +250,15 @@ function run(e: EffectNode): void {
 			&& checkDirty(e.deps!, e)
 		)
 	) {
-		++cycle;
 		e.depsTail = undefined;
 		e.flags = ReactiveFlags.Watching | ReactiveFlags.RecursedCheck;
 		const prevSub = setActiveSub(e);
 		try {
+			++cycle;
+			++runDepth;
 			e.fn();
 		} finally {
+			--runDepth;
 			activeSub = prevSub;
 			e.flags &= ~ReactiveFlags.RecursedCheck;
 			purgeDeps(e);
@@ -301,8 +308,10 @@ function computedOper<T>(this: ComputedNode<T>): T {
 		this.flags = ReactiveFlags.Mutable | ReactiveFlags.RecursedCheck;
 		const prevSub = setActiveSub(this);
 		try {
+			++runDepth;
 			this.value = this.getter();
 		} finally {
+			--runDepth;
 			activeSub = prevSub;
 			this.flags &= ~ReactiveFlags.RecursedCheck;
 		}
@@ -320,7 +329,7 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T]): T | void {
 			this.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
 			const subs = this.subs;
 			if (subs !== undefined) {
-				propagate(subs);
+				propagate(subs, !!runDepth);
 				if (!batchDepth) {
 					flush();
 				}

--- a/src/system.ts
+++ b/src/system.ts
@@ -115,7 +115,7 @@ export function createReactiveSystem({
 		return nextDep;
 	}
 
-	function propagate(link: Link): void {
+	function propagate(link: Link, innerWrite: boolean): void {
 		let next = link.nextSub;
 		let stack: Stack<Link | undefined> | undefined;
 
@@ -125,6 +125,9 @@ export function createReactiveSystem({
 
 			if (!(flags & (ReactiveFlags.RecursedCheck | ReactiveFlags.Recursed | ReactiveFlags.Dirty | ReactiveFlags.Pending))) {
 				sub.flags = flags | ReactiveFlags.Pending;
+				if (innerWrite) {
+					sub.flags |= ReactiveFlags.Recursed;
+				}
 			} else if (!(flags & (ReactiveFlags.RecursedCheck | ReactiveFlags.Recursed))) {
 				flags = ReactiveFlags.None;
 			} else if (!(flags & ReactiveFlags.RecursedCheck)) {

--- a/tests/issue_99.spec.ts
+++ b/tests/issue_99.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest';
+import { computed, effect, effectScope, signal } from '../src';
+
+test('#99 consecutive inner resets through computed chain', () => {
+	const s = signal(0);
+	const c = computed(() => s());
+	let runs = 0;
+
+	effect(() => {
+		runs++;
+		if (c() > 0) {
+			s(0);
+		}
+	});
+
+	expect(runs).toBe(1);
+	s(1);
+	expect(s()).toBe(0);
+	s(2);
+	expect(s()).toBe(0);
+	s(3);
+	expect(s()).toBe(0);
+});

--- a/tests/issue_99.spec.ts
+++ b/tests/issue_99.spec.ts
@@ -16,8 +16,11 @@ test('#99 consecutive inner resets through computed chain', () => {
 	expect(runs).toBe(1);
 	s(1);
 	expect(s()).toBe(0);
+	expect(runs).toBe(2);
 	s(2);
 	expect(s()).toBe(0);
+	expect(runs).toBe(3);
 	s(3);
 	expect(s()).toBe(0);
+	expect(runs).toBe(4);
 });

--- a/tests/issue_99.spec.ts
+++ b/tests/issue_99.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { computed, effect, effectScope, signal } from '../src';
+import { computed, effect, signal } from '../src';
 
 test('#99 consecutive inner resets through computed chain', () => {
 	const s = signal(0);


### PR DESCRIPTION
## Problem

When an effect writes to a signal during execution (inner write) and the dependency goes through a computed node, the propagation gets blocked on subsequent external writes.

```ts
const s = signal(0);
const c = computed(() => s());

effect(() => {
  if (c() > 0) {
    s(0); // inner write
  }
});

s(1); expect(s()).toBe(0); // ✓
s(2); expect(s()).toBe(0); // ✗ — blocked, s() is still 2
s(3); expect(s()).toBe(0); // ✗ — blocked
```

**Root cause**: The inner write marks computed `c` with only `Pending`. On the next external write, `propagate` Branch 2 sees the existing `Pending` (without `Recursed`) and stops traversal — the effect is never notified.

## Fix

Add an `innerWrite` boolean parameter to `propagate()`, derived from a global `runDepth` counter that tracks whether code is executing inside an effect or computed. During inner writes, Branch 1 additionally gives `Mutable` nodes (computeds) the `Recursed` flag, so the next propagation hits Branch 3 (clears `Recursed`, continues) instead of Branch 2 (blocks).

Changes:
- `src/system.ts`: `propagate(link, innerWrite)` — 3 lines added to Branch 1
- `src/index.ts`: `runDepth` counter incremented/decremented in 4 places (paired with `RecursedCheck`), passed as `!!runDepth` at 2 `propagate` call sites