### PR TITLE
Fix nested-effect cleanup order and add LIFO disposal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createReactiveSystem, ReactiveFlags, type Link, type ReactiveNode } from './system.js';
+import { createReactiveSystem, ReactiveFlags, type ReactiveNode } from './system.js';
 
 interface EffectScopeNode extends ReactiveNode {
 }
@@ -74,13 +74,7 @@ const {
 		if ('getter' in node) {
 			if (node.depsTail !== undefined) {
 				node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
-				let link: Link | undefined = node.depsTail;
-				node.depsTail = undefined;
-				while (link !== undefined) {
-					const prev: Link | undefined = link.prevDep;
-					unlink(link, node);
-					link = prev;
-				}
+				disposeAllDepsInReverse(node);
 			}
 		}
 		else if ('currentValue' in node) {
@@ -421,15 +415,19 @@ function effectOper(this: EffectNode): void {
 
 function effectScopeOper(this: EffectScopeNode): void {
 	this.flags = ReactiveFlags.None;
-	let link = this.depsTail;
-	while (link !== undefined) {
-		const prev = link.prevDep;
-		unlink(link, this);
-		link = prev;
-	}
+	disposeAllDepsInReverse(this);
 	const sub = this.subs;
 	if (sub !== undefined) {
 		unlink(sub);
+	}
+}
+
+function disposeAllDepsInReverse(sub: ReactiveNode): void {
+	let link = sub.depsTail;
+	while (link !== undefined) {
+		const prev = link.prevDep;
+		unlink(link, sub);
+		link = prev;
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { createReactiveSystem, ReactiveFlags, type ReactiveNode } from './system.js';
+import { createReactiveSystem, ReactiveFlags, type Link, type ReactiveNode } from './system.js';
 
 interface EffectScopeNode extends ReactiveNode {
 }
@@ -77,10 +77,10 @@ const {
 		else if ('getter' in node) {
 			if (node.depsTail !== undefined) {
 				node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
-				let link = node.depsTail;
+				let link: Link | undefined = node.depsTail;
 				node.depsTail = undefined;
 				while (link !== undefined) {
-					const prev = link.prevDep;
+					const prev: Link | undefined = link.prevDep;
 					unlink(link, node);
 					link = prev;
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,14 @@ const {
 		}
 		else if ('getter' in node) {
 			if (node.depsTail !== undefined) {
-				node.depsTail = undefined;
 				node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
-				purgeDeps(node);
+				let link = node.depsTail;
+				node.depsTail = undefined;
+				while (link !== undefined) {
+					const prev = link.prevDep;
+					unlink(link, node);
+					link = prev;
+				}
 			}
 		}
 		else if ('currentValue' in node) {
@@ -200,6 +205,7 @@ export function effectScope(fn: () => void): () => void {
 	const prevSub = setActiveSub(e);
 	if (prevSub !== undefined) {
 		link(e, prevSub, 0);
+		prevSub.flags |= HasChildEffect;
 	}
 	try {
 		fn();
@@ -242,7 +248,8 @@ function updateComputed(c: ComputedNode): boolean {
 		let link = c.depsTail;
 		while (link !== undefined) {
 			const prev = link.prevDep;
-			if ('fn' in link.dep) {
+			const dep = link.dep;
+			if (!('getter' in dep) && !('currentValue' in dep)) {
 				unlink(link, c);
 			}
 			link = prev;
@@ -280,7 +287,8 @@ function run(e: EffectNode): void {
 			let link = e.depsTail;
 			while (link !== undefined) {
 				const prev = link.prevDep;
-				if ('fn' in link.dep) {
+				const dep = link.dep;
+				if (!('getter' in dep) && !('currentValue' in dep)) {
 					unlink(link, e);
 				}
 				link = prev;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ interface SignalNode<T = any> extends ReactiveNode {
 	pendingValue: T;
 }
 
+// Marks a parent (effect or scope) whose deps include at least one child
+// effect. Used to gate the dispose-children-first slow path in run() so
+// leaf effects (no children, no own cleanup) avoid the extra deps walk.
+// The bit is outside ReactiveFlags' range and never touched by system.ts.
+const HasChildEffect = 64;
+
 let cycle = 0;
 let runDepth = 0;
 let batchDepth = 0;
@@ -64,13 +70,22 @@ const {
 			queued[insertIndex] = left;
 		}
 	},
-	unwatched(node) {
-		if (!(node.flags & ReactiveFlags.Mutable)) {
+	unwatched(node: SignalNode | ComputedNode | EffectNode | EffectScopeNode) {
+		if ('fn' in node) {
+			effectOper.call(node);
+		}
+		else if ('getter' in node) {
+			if (node.depsTail !== undefined) {
+				node.depsTail = undefined;
+				node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
+				purgeDeps(node);
+			}
+		}
+		else if ('currentValue' in node) {
+			// Nothing to do for signals, they are always mutable and never dirty until pendingValue changes
+		}
+		else {
 			effectScopeOper.call(node);
-		} else if (node.depsTail !== undefined) {
-			node.depsTail = undefined;
-			node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
-			purgeDeps(node);
 		}
 	},
 });
@@ -161,6 +176,7 @@ export function effect(fn: () => void | (() => void)): () => void {
 	const prevSub = setActiveSub(e);
 	if (prevSub !== undefined) {
 		link(e, prevSub, 0);
+		prevSub.flags |= HasChildEffect;
 	}
 	try {
 		++runDepth;
@@ -222,6 +238,16 @@ export function trigger(fn: () => void) {
 }
 
 function updateComputed(c: ComputedNode): boolean {
+	if (c.flags & HasChildEffect) {
+		let link = c.depsTail;
+		while (link !== undefined) {
+			const prev = link.prevDep;
+			if ('fn' in link.dep) {
+				unlink(link, c);
+			}
+			link = prev;
+		}
+	}
 	c.depsTail = undefined;
 	c.flags = ReactiveFlags.Mutable | ReactiveFlags.RecursedCheck;
 	const prevSub = setActiveSub(c);
@@ -250,6 +276,16 @@ function run(e: EffectNode): void {
 			&& checkDirty(e.deps!, e)
 		)
 	) {
+		if (flags & HasChildEffect) {
+			let link = e.depsTail;
+			while (link !== undefined) {
+				const prev = link.prevDep;
+				if ('fn' in link.dep) {
+					unlink(link, e);
+				}
+				link = prev;
+			}
+		}
 		if (e.cleanup) {
 			runCleanup(e);
 			if (!e.flags) {
@@ -270,7 +306,7 @@ function run(e: EffectNode): void {
 			purgeDeps(e);
 		}
 	} else if (e.deps !== undefined) {
-		e.flags = ReactiveFlags.Watching;
+		e.flags = ReactiveFlags.Watching | (flags & HasChildEffect);
 	}
 }
 
@@ -369,16 +405,20 @@ function runCleanup(e: EffectNode): void {
 }
 
 function effectOper(this: EffectNode): void {
+	effectScopeOper.call(this);
 	if (this.cleanup) {
 		runCleanup(this);
 	}
-	effectScopeOper.call(this);
 }
 
 function effectScopeOper(this: EffectScopeNode): void {
-	this.depsTail = undefined;
 	this.flags = ReactiveFlags.None;
-	purgeDeps(this);
+	let link = this.depsTail;
+	while (link !== undefined) {
+		const prev = link.prevDep;
+		unlink(link, this);
+		link = prev;
+	}
 	const sub = this.subs;
 	if (sub !== undefined) {
 		unlink(sub);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,10 +71,7 @@ const {
 		}
 	},
 	unwatched(node: SignalNode | ComputedNode | EffectNode | EffectScopeNode) {
-		if ('fn' in node) {
-			effectOper.call(node);
-		}
-		else if ('getter' in node) {
+		if ('getter' in node) {
 			if (node.depsTail !== undefined) {
 				node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty;
 				let link: Link | undefined = node.depsTail;
@@ -88,6 +85,9 @@ const {
 		}
 		else if ('currentValue' in node) {
 			// Nothing to do for signals, they are always mutable and never dirty until pendingValue changes
+		}
+		else if ('fn' in node) {
+			effectOper.call(node);
 		}
 		else {
 			effectScopeOper.call(node);

--- a/tests/effect.spec.ts
+++ b/tests/effect.spec.ts
@@ -129,6 +129,22 @@ test('three-level nested cleanup on dispose: deepest first (depth-first reverse)
 	]);
 });
 
+test('computed unwatched: child effect cleanups run in reverse creation (LIFO)', () => {
+	// When the computed loses its last subscriber and gets unwatched, any
+	// effects it created during its getter must be cleaned up LIFO, not FIFO.
+	const log: string[] = [];
+	const c = computed(() => {
+		effect(() => () => log.push('e1'));
+		effect(() => () => log.push('e2'));
+		effect(() => () => log.push('e3'));
+		return 0;
+	});
+	const dispose = effect(() => { c(); });
+	log.length = 0;
+	dispose();
+	expect(log).toEqual(['e3', 'e2', 'e1']);
+});
+
 test('effect created inside computed: old inner cleanup runs before new inner setup', () => {
 	// When a computed re-evaluates, any effects its getter created on the
 	// previous run must be disposed (with cleanup) before the getter runs

--- a/tests/effect.spec.ts
+++ b/tests/effect.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { effect, getActiveSub, signal } from '../src';
+import { computed, effect, getActiveSub, signal } from '../src';
 import { ReactiveFlags } from '../src/system';
 
 test('should support custom recurse effect', () => {
@@ -14,6 +14,181 @@ test('should support custom recurse effect', () => {
 	});
 
 	expect(triggers).toBe(6);
+});
+
+test('cleanup order on outer re-run: inner before outer, before new run', () => {
+	const log: string[] = [];
+	const a = signal(0);
+
+	effect(() => {
+		a();
+		log.push('outer:run');
+		effect(() => {
+			log.push('inner:run');
+			return () => log.push('inner:cleanup');
+		});
+		return () => log.push('outer:cleanup');
+	});
+	expect(log).toEqual(['outer:run', 'inner:run']);
+
+	log.length = 0;
+	a(1);
+	expect(log).toEqual([
+		'inner:cleanup',
+		'outer:cleanup',
+		'outer:run',
+		'inner:run',
+	]);
+});
+
+test('cleanup order on dispose: inner before outer', () => {
+	const log: string[] = [];
+
+	const dispose = effect(() => {
+		log.push('outer:run');
+		effect(() => {
+			log.push('inner:run');
+			return () => log.push('inner:cleanup');
+		});
+		return () => log.push('outer:cleanup');
+	});
+	log.length = 0;
+	dispose();
+	expect(log).toEqual(['inner:cleanup', 'outer:cleanup']);
+});
+
+test('sibling cleanup order on dispose: reverse creation (LIFO)', () => {
+	const log: string[] = [];
+
+	const dispose = effect(() => {
+		effect(() => {
+			return () => log.push('inner1:cleanup');
+		});
+		effect(() => {
+			return () => log.push('inner2:cleanup');
+		});
+		effect(() => {
+			return () => log.push('inner3:cleanup');
+		});
+		return () => log.push('outer:cleanup');
+	});
+	dispose();
+	expect(log).toEqual([
+		'inner3:cleanup',
+		'inner2:cleanup',
+		'inner1:cleanup',
+		'outer:cleanup',
+	]);
+});
+
+test('sibling cleanup order on outer re-run: reverse creation (LIFO)', () => {
+	const log: string[] = [];
+	const a = signal(0);
+
+	effect(() => {
+		a();
+		effect(() => {
+			return () => log.push('inner1:cleanup');
+		});
+		effect(() => {
+			return () => log.push('inner2:cleanup');
+		});
+		effect(() => {
+			return () => log.push('inner3:cleanup');
+		});
+		return () => log.push('outer:cleanup');
+	});
+	log.length = 0;
+
+	a(1);
+	expect(log.slice(0, 4)).toEqual([
+		'inner3:cleanup',
+		'inner2:cleanup',
+		'inner1:cleanup',
+		'outer:cleanup',
+	]);
+});
+
+test('three-level nested cleanup on dispose: deepest first (depth-first reverse)', () => {
+	const log: string[] = [];
+
+	const dispose = effect(() => {
+		effect(() => {
+			effect(() => {
+				return () => log.push('grandchild:cleanup');
+			});
+			return () => log.push('child:cleanup');
+		});
+		return () => log.push('outer:cleanup');
+	});
+	dispose();
+	expect(log).toEqual([
+		'grandchild:cleanup',
+		'child:cleanup',
+		'outer:cleanup',
+	]);
+});
+
+test('effect created inside computed: old inner cleanup runs before new inner setup', () => {
+	// When a computed re-evaluates, any effects its getter created on the
+	// previous run must be disposed (with cleanup) before the getter runs
+	// again. Otherwise the old inner's cleanup ends up running after the
+	// new inner has already been set up.
+	const a = signal(0);
+	const log: string[] = [];
+
+	const c = computed(() => {
+		log.push('computed:eval');
+		effect(() => {
+			log.push('inner:run');
+			return () => log.push('inner:cleanup');
+		});
+		return a();
+	});
+
+	effect(() => {
+		c();
+	});
+	log.length = 0;
+
+	a(1);
+	expect(log).toEqual([
+		'inner:cleanup',
+		'computed:eval',
+		'inner:run',
+	]);
+});
+
+test('cleanup order is correct on outer re-run after a prior inner-only re-run', () => {
+	// Regression: inner re-running alone routes outer through run()'s
+	// not-dirty branch (restore Watching), which must preserve any
+	// "has child effect" tracking so the next real outer re-run still
+	// disposes children before its own cleanup.
+	const a = signal(0);
+	const b = signal(0);
+	const log: string[] = [];
+
+	effect(() => {
+		a();
+		log.push('outer:run');
+		effect(() => {
+			b();
+			log.push('inner:run');
+			return () => log.push('inner:cleanup');
+		});
+		return () => log.push('outer:cleanup');
+	});
+
+	b(1); // inner re-runs alone; outer is touched via notify chain
+	log.length = 0;
+
+	a(1);
+	expect(log).toEqual([
+		'inner:cleanup',
+		'outer:cleanup',
+		'outer:run',
+		'inner:run',
+	]);
 });
 
 // https://github.com/stackblitz/alien-signals/issues/115

--- a/tests/effectScope.spec.ts
+++ b/tests/effectScope.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { effect, effectScope } from '../src';
+import { effect, effectScope, signal } from '../src';
 
 test('scope dispose runs child effect cleanup', () => {
 	const log: string[] = [];
@@ -41,4 +41,33 @@ test('scope dispose: nested effect cleanup runs depth-first reverse', () => {
 	});
 	dispose();
 	expect(log).toEqual(['grandchild:cleanup', 'child:cleanup']);
+});
+
+test('scope as intermediate parent: cleanup order respects nesting', () => {
+	// When effectScope is used as an intermediate scope inside an outer
+	// effect, the outer's re-run must still dispose the scope (and its
+	// effects) before running the outer's own cleanup.
+	const a = signal(0);
+	const log: string[] = [];
+
+	effect(() => {
+		a();
+		log.push('outer:run');
+		effectScope(() => {
+			effect(() => {
+				log.push('inner:run');
+				return () => log.push('inner:cleanup');
+			});
+		});
+		return () => log.push('outer:cleanup');
+	});
+	log.length = 0;
+
+	a(1);
+	expect(log).toEqual([
+		'inner:cleanup',
+		'outer:cleanup',
+		'outer:run',
+		'inner:run',
+	]);
 });

--- a/tests/effectScope.spec.ts
+++ b/tests/effectScope.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest';
+import { effect, effectScope } from '../src';
+
+test('scope dispose runs child effect cleanup', () => {
+	const log: string[] = [];
+	const dispose = effectScope(() => {
+		effect(() => {
+			return () => log.push('inner:cleanup');
+		});
+	});
+	dispose();
+	expect(log).toEqual(['inner:cleanup']);
+});
+
+test('scope dispose: sibling effects clean up in reverse creation (LIFO)', () => {
+	const log: string[] = [];
+	const dispose = effectScope(() => {
+		effect(() => {
+			return () => log.push('e1:cleanup');
+		});
+		effect(() => {
+			return () => log.push('e2:cleanup');
+		});
+		effect(() => {
+			return () => log.push('e3:cleanup');
+		});
+	});
+	dispose();
+	expect(log).toEqual(['e3:cleanup', 'e2:cleanup', 'e1:cleanup']);
+});
+
+test('scope dispose: nested effect cleanup runs depth-first reverse', () => {
+	const log: string[] = [];
+	const dispose = effectScope(() => {
+		effect(() => {
+			effect(() => {
+				return () => log.push('grandchild:cleanup');
+			});
+			return () => log.push('child:cleanup');
+		});
+	});
+	dispose();
+	expect(log).toEqual(['grandchild:cleanup', 'child:cleanup']);
+});


### PR DESCRIPTION
## Summary

Two bugs in cleanup of nested effects:

1. **Inner cleanup never ran on auto-dispose.** When an inner effect was disposed by the parent re-running or being disposed (rather than by the user calling its own dispose function), `unwatched` routed it straight to `effectScopeOper`, which only clears state — `.cleanup` was never read. Inner cleanup was silently dropped on every auto-dispose path.

2. **Order was inverted.** Even with cleanup hooked into auto-dispose, the parent's own cleanup ran first; children were disposed afterwards via `purgeDeps`. Standard reverse-of-creation order requires:
   - Inner cleanup before outer cleanup (so the inner can still rely on whatever state the outer set up).
   - Old inner cleanup before the body re-runs (so it doesn't clean up state the new inner already set up).

## Changes

### Routing — `unwatched` dispatches by node shape

```ts
unwatched(node) {
  if ('fn' in node) effectOper.call(node);          // EffectNode → full dispose
  else if ('getter' in node) { /* stale clear */ }  // ComputedNode
  else if ('currentValue' in node) { /* noop */ }   // SignalNode
  else effectScopeOper.call(node);                  // EffectScopeNode / trigger sub
}
```

### Pre-walk children before own cleanup

`effectOper`, `effectScopeOper`, `run()`, and `updateComputed` all walk `this.depsTail` backward and `unlink` child EffectNode deps before the node's own cleanup runs. `unlink` triggers `unwatched` → recursive `effectOper` on each child, so grandchildren clean up depth-first reverse before their parent.

### Fast path — `HasChildEffect` flag

A new bit defined locally in `index.ts` (outside `ReactiveFlags`' range so `system.ts` never touches it). `effect()` sets it on the parent when linking; `run()` and `updateComputed` check it before doing the pre-walk. Leaf effects with no child effects skip the walk entirely.

The flag is dynamic — it's cleared at the start of every body re-run and re-set if the body creates new children. So an effect that stops creating children moves back to the fast path automatically.

The `else if` branch of `run()` (the parent-chain-notify case where outer is queued but not dirty) explicitly preserves the flag: `e.flags = Watching | (flags & HasChildEffect)`. Otherwise an inner-only re-run clobbers the outer's bit and the next real re-run skips the pre-walk.

## Tests

`tests/effect.spec.ts`:
- cleanup order on outer re-run
- cleanup order on dispose
- sibling cleanup order (LIFO) on dispose / re-run
- three-level nested cleanup
- cleanup order after a prior inner-only re-run (regression for the bit-loss path)
- effect created inside computed (`updateComputed` regression)

`tests/effectScope.spec.ts` (new):
- scope dispose runs child cleanup
- sibling LIFO on scope dispose
- depth-first reverse for nested in scope

198 passing.