### PR TITLE
Add `main` and `module` fields for resolvers without `exports` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
 	"description": "The lightest signal library.",
 	"packageManager": "pnpm@9.12.0",
 	"types": "./types/index.d.ts",
+	"main": "./cjs/index.cjs",
+	"module": "./esm/index.mjs",
 	"exports": {
 		".": {
 			"types": "./types/index.d.ts",

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { expect } from 'vitest';
 import { test } from 'vitest';
 
@@ -17,4 +18,22 @@ test('build: esm', async () => {
 
 	expect(typeof index.getActiveSub).toBe('function');
 	expect(typeof system.createReactiveSystem).toBe('function');
+});
+
+test('build: entry fields', () => {
+	const pkg = require('../package.json');
+	const root = new URL('../', import.meta.url);
+
+	// Resolvers that predate `exports`, such as webpack 4, only see these.
+	expect(pkg.main).toBe('./cjs/index.cjs');
+	expect(pkg.module).toBe('./esm/index.mjs');
+
+	const entries: string[] = [pkg.main, pkg.module, pkg.types];
+	for (const conditions of Object.values(pkg.exports)) {
+		entries.push(...Object.values(conditions as Record<string, string>));
+	}
+
+	for (const entry of entries) {
+		expect(existsSync(new URL(entry, root)), entry).toBe(true);
+	}
 });


### PR DESCRIPTION
The package is `exports`-only, so resolvers that predate `exports` — webpack 4
(react-scripts 4) in particular — can't find it at all:
`Cannot find module: 'alien-signals'`.

This adds two fallback fields pointing at files that are already published:

```json
"main": "./cjs/index.cjs",
"module": "./esm/index.mjs",

exports still wins everywhere it's understood, so nothing changes for Node,
webpack 5, Vite or Rollup — verified, along with build, tests and tsslint.
```